### PR TITLE
feat(web): add marketing website and Cloudflare Pages deploy

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,0 +1,31 @@
+name: Deploy Website
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/web/**"
+
+jobs:
+  deploy:
+    name: Deploy to Cloudflare Pages
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-${{ runner.os }}-
+      - run: bun install --frozen-lockfile
+      - run: cd apps/web && bun run build
+      - uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy apps/web/dist --project-name=sandcaster-web


### PR DESCRIPTION
## Summary

- Add full Astro 5 static marketing site at `apps/web/` with landing page, docs (7 pages), blog, and changelog
- Include components: IDEPanel demo, feature cards, terminal blocks, docs sidebar with mobile nav
- Add Cloudflare Pages deploy workflow triggered on push to `main` when `apps/web/**` changes
- Configure Biome root for Tailwind CSS class sorting

## Test plan

- [x] `bun run build` in `apps/web/` succeeds (13 pages generated)
- [x] Navigation unit tests pass
- [ ] Merge to `main` → deploy workflow triggers and deploys to `sandcaster-web.pages.dev`
- [ ] Set custom domain `getsandcaster.com` via Cloudflare Pages dashboard