### PR TITLE
ci(web): add workflow_dispatch for initial deploy

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - "apps/web/**"
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
## Summary

- Add `workflow_dispatch` trigger to the deploy workflow so it can be run manually

The initial merge of PR #17 didn't trigger the deploy because GitHub Actions doesn't fire path-filtered workflows when the workflow file itself is new in the same push. Adding manual trigger lets us kick off the first deploy.

## Test plan

- [ ] Merge this PR, then run the workflow manually via Actions tab → "Deploy Website" → "Run workflow"