### PR TITLE
ci: add npm environment for OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'success'
+    environment: npm
     timeout-minutes: 15
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- Add `environment: npm` to release workflow job for OIDC trusted publishing

Required for npm provenance — the GitHub Environment links the workflow to npm's trusted publisher configuration.

## Test plan

- [x] Workflow syntax is valid
- [ ] Next automated release will validate OIDC auth end-to-end