### PR TITLE
chore: test release pipeline with changeset

### DIFF
--- a/.changeset/test-release-pipeline.md
+++ b/.changeset/test-release-pipeline.md
@@ -1,0 +1,6 @@
+---
+"@sandcaster/sdk": patch
+"@sandcaster/cli": patch
+---
+
+Initial release infrastructure setup


### PR DESCRIPTION
## Summary

- Add a patch changeset for both `@sandcaster/sdk` and `@sandcaster/cli` to test the automated release pipeline

## What happens after merge

1. CI runs on main
2. Release workflow triggers (via `workflow_run`)
3. `changesets/action` detects the changeset and opens a "Version Packages" PR
4. Merging that PR bumps versions to 0.1.1, publishes to npm with OIDC provenance, creates GitHub Releases, and syncs changelog to website