### PR TITLE
docs: add README.md to npm-published packages

### DIFF
--- a/.changeset/add-package-readmes.md
+++ b/.changeset/add-package-readmes.md
@@ -1,0 +1,6 @@
+---
+"@sandcaster/sdk": patch
+"@sandcaster/cli": patch
+---
+
+Add README.md to npm-published packages so npmjs.com pages show documentation

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -1,0 +1,70 @@
+# @sandcaster/cli
+
+CLI for [Sandcaster](https://github.com/iamladi/sandcaster) — run AI agents in isolated sandboxes.
+
+[![npm](https://img.shields.io/npm/v/@sandcaster/cli)](https://www.npmjs.com/package/@sandcaster/cli)
+[![license](https://img.shields.io/npm/l/@sandcaster/cli)](https://github.com/iamladi/sandcaster/blob/main/LICENSE)
+
+## Install
+
+```bash
+npm i -g @sandcaster/cli
+```
+
+## Quick start
+
+```bash
+# Initialize a project from a starter template
+sandcaster init general-assistant
+
+# Run a query
+sandcaster "Compare Notion, Coda, and Slite for async product teams"
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `sandcaster <prompt>` | Run an AI agent in a sandbox (default command) |
+| `sandcaster init [starter] [dir]` | Initialize a `sandcaster.json` config from a starter |
+| `sandcaster serve` | Start the Sandcaster API server |
+| `sandcaster session list` | List active and recent sessions |
+| `sandcaster session attach <id>` | Attach to a live session |
+| `sandcaster session delete <id>` | Delete a session |
+| `sandcaster templates [name]` | List and inspect available templates |
+
+### Query options
+
+```
+-T, --template <name>       Use a starter template
+-m, --model <model>         Model override
+-f, --file <path>           Upload files (repeatable)
+-t, --timeout <secs>        Sandbox timeout
+    --max-turns <n>         Max agent turns
+    --no-tui                Output JSON lines instead of TUI
+-B, --branches <n>          Parallel branches (1-5)
+    --branch-trigger <mode> Branch trigger (explicit, confidence, always)
+    --evaluator <type>      Evaluator (llm-judge, schema, custom)
+    --provider <name>       LLM provider (anthropic, vertex, bedrock, openrouter)
+```
+
+## Starters
+
+Use `sandcaster init <starter>` to scaffold a project:
+
+| Starter | Description | Aliases |
+|---------|-------------|---------|
+| `general-assistant` | General-purpose agent for mixed workflows | — |
+| `research-brief` | Research a topic and return a decision brief | `competitive-analysis` |
+| `document-analyst` | Analyze transcripts, reports, PDFs, or decks | — |
+| `support-triage` | Triage tickets into priorities and next actions | `issue-triage` |
+| `api-extractor` | Crawl docs and draft an OpenAPI spec | `docs-to-openapi` |
+| `security-audit` | Structured security review with sub-agents | — |
+
+## Configuration
+
+Projects are configured via `sandcaster.json`. Run `sandcaster init` to generate one, or see the [main repo](https://github.com/iamladi/sandcaster) for the full schema.
+
+## License
+
+MIT — see the [main repo](https://github.com/iamladi/sandcaster) for full documentation.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -20,7 +20,8 @@
 		"node": ">=20"
 	},
 	"files": [
-		"dist"
+		"dist",
+		"README.md"
 	],
 	"bin": {
 		"sandcaster": "./dist/index.js"

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,0 +1,101 @@
+# @sandcaster/sdk
+
+TypeScript SDK for [Sandcaster](https://github.com/iamladi/sandcaster) — run AI agents in isolated sandboxes.
+
+[![npm](https://img.shields.io/npm/v/@sandcaster/sdk)](https://www.npmjs.com/package/@sandcaster/sdk)
+[![license](https://img.shields.io/npm/l/@sandcaster/sdk)](https://github.com/iamladi/sandcaster/blob/main/LICENSE)
+
+## Install
+
+```bash
+npm i @sandcaster/sdk
+```
+
+## Quick start
+
+```ts
+import { SandcasterClient } from "@sandcaster/sdk";
+
+const client = new SandcasterClient({
+  baseUrl: "http://localhost:8000",
+  apiKey: "your-api-key",
+});
+
+for await (const event of client.query({ prompt: "Summarize the top HN stories" })) {
+  if (event.type === "assistant") {
+    process.stdout.write(event.content);
+  }
+}
+```
+
+### Sessions
+
+Sessions keep sandbox state alive between messages:
+
+```ts
+let sessionId: string;
+
+for await (const event of client.createSession({ prompt: "Set up a Python project" })) {
+  if (event.type === "session_created") sessionId = event.sessionId;
+}
+
+for await (const event of client.sendSessionMessage(sessionId, { prompt: "Add a test suite" })) {
+  if (event.type === "assistant") process.stdout.write(event.content);
+}
+```
+
+### Cleanup
+
+The client implements `Symbol.asyncDispose`, so all in-flight requests are aborted when the scope exits:
+
+```ts
+await using client = new SandcasterClient({ baseUrl: "http://localhost:8000" });
+// requests abort automatically when `client` goes out of scope
+```
+
+## API
+
+All streaming methods return `AsyncIterable<SandcasterEvent>` and accept an optional `{ signal?: AbortSignal }`.
+
+| Method | Description |
+|--------|-------------|
+| `query(request)` | Stream a one-shot agent query |
+| `createSession(request)` | Create a persistent session and run the first query |
+| `sendSessionMessage(id, message)` | Send a follow-up message to a session |
+| `attachSession(id)` | Attach to a running session and observe events |
+| `listSessions()` | List all sessions |
+| `getSession(id)` | Get session details |
+| `deleteSession(id)` | Delete a session |
+| `health()` | Server health check |
+| `listRuns()` | List all runs |
+
+## Event types
+
+Events are a discriminated union on `type`. The core types are:
+
+| Type | Description |
+|------|-------------|
+| `system` | System messages (sandbox ready, etc.) |
+| `assistant` | Model output (`delta` or `complete`) |
+| `thinking` | Model thinking (`delta` or `complete`) |
+| `tool_use` | Tool invocation |
+| `tool_result` | Tool output (includes `isError`) |
+| `file` | File created/modified in the sandbox |
+| `result` | Final result with cost, turns, and duration |
+| `error` | Error with optional `code` and `hint` |
+| `warning` | Non-fatal warning |
+| `stderr` | Stderr output from the sandbox |
+| `session_created` | Session created with `sessionId` |
+| `session_expired` | Session timed out |
+| `session_command_result` | Session command result |
+| `branch_start` | Branch execution started |
+| `branch_progress` | Branch progress update |
+| `branch_complete` | Branch finished |
+| `branch_selected` | Winning branch chosen by evaluator |
+| `branch_summary` | Summary of all branches |
+| `branch_request` | Agent requested branching |
+| `confidence_report` | Agent confidence level |
+
+## License
+
+MIT — see the [main repo](https://github.com/iamladi/sandcaster) for full documentation.


### PR DESCRIPTION
## Summary

- Add `README.md` to `@sandcaster/sdk` and `@sandcaster/cli` so their npmjs.com pages display documentation
- Add `README.md` to the CLI `files` array in `package.json` (SDK already had it listed)
- Add changeset for patch bump of both packages

## Details

**SDK README** covers: install, quick start (one-shot queries, sessions, async dispose), API method table, and event types table.

**CLI README** covers: install, quick start (`init` + `query`), commands table, query options, starters table, and config pointer.

## Test plan

- [x] `npm pack --dry-run` in both packages confirms README.md is included
- [x] `bunx turbo build` passes