### PR TITLE
docs: update README to reflect current project state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 [![CI](https://github.com/iamladi/sandcaster/actions/workflows/ci.yml/badge.svg)](https://github.com/iamladi/sandcaster/actions/workflows/ci.yml)
+[![npm: sdk](https://img.shields.io/npm/v/@sandcaster/sdk?label=sdk)](https://www.npmjs.com/package/@sandcaster/sdk)
+[![npm: cli](https://img.shields.io/npm/v/@sandcaster/cli?label=cli)](https://www.npmjs.com/package/@sandcaster/cli)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.9+-blue.svg)](https://www.typescriptlang.org/)
 [![Bun](https://img.shields.io/badge/Bun-1.2+-f472b6.svg)](https://bun.sh/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
@@ -7,7 +9,7 @@
 
 Open-source runtime for general-purpose AI agents in isolated sandboxes.
 
-CLI, API, TypeScript SDK, and Slack with streaming, file uploads, and config-driven behavior.
+CLI, API, TypeScript SDK, and chat bots (Slack, Discord, Telegram) with streaming, file uploads, and config-driven behavior.
 
 Built on [Pi-mono](https://github.com/badlogic/pi-mono) for multi-provider LLM orchestration and pluggable sandbox backends ([E2B](https://e2b.dev), [Vercel](https://vercel.com/docs/sandbox), Docker, [Cloudflare Containers](https://developers.cloudflare.com/containers/)).
 
@@ -18,6 +20,7 @@ Sandcaster is a TypeScript rewrite of [Sandstorm](https://github.com/tomascupr/s
 - Triage incoming support tickets
 - Run a security audit with coordinated sub-agents across multiple sandboxes
 - Turn docs into a draft OpenAPI spec
+- Deploy a chat bot that runs sandboxed agents from Slack, Discord, or Telegram
 
 ## Terminal demo
 
@@ -45,40 +48,53 @@ its work in a rich TUI, and tears itself down when the run is done.
 ## 60-second path
 
 ```bash
+# from npm
+npx @sandcaster/cli init hello-sandbox
+cd hello-sandbox
+npx @sandcaster/cli "What can you do in this sandbox?"
+
+# or from source
 git clone https://github.com/iamladi/sandcaster.git
 cd sandcaster
 bun install && bunx turbo build
 cd apps/cli && bun link      # registers the `sandcaster` command globally
 
-sandcaster init general-assistant
-cd general-assistant
-sandcaster "Compare Notion, Coda, and Slite for async product teams"
+sandcaster init hello-sandbox
+cd hello-sandbox
+sandcaster "What can you do in this sandbox?"
 ```
 
-`sandcaster init <starter>` scaffolds a runnable starter with `sandcaster.json`, a starter README,
+`sandcaster init <starter>` scaffolds a runnable project with `sandcaster.json`, a README,
 `.env.example`, and any starter-specific assets. If provider env vars are detected in your shell,
 Sandcaster writes `.env` automatically.
 
-Direct forms:
-
 ```bash
-sandcaster init --list
-sandcaster init research-brief
-sandcaster init security-audit my-audit
+sandcaster init --list              # list all starters
+sandcaster init research-brief      # scaffold into ./research-brief
+sandcaster init security-audit my-audit  # scaffold into ./my-audit
 ```
 
-## Pick a starter
+## Examples
 
-| Starter | Use it when you want to | Typical output | Aliases |
-|---------|--------------------------|----------------|---------|
-| `general-assistant` | Start with one flexible agent for mixed workflows | concise answer, plan, or artifact | - |
-| `research-brief` | Research a topic, compare options, and support a decision | brief with findings, recommendations, and sources | `competitive-analysis` |
-| `document-analyst` | Review transcripts, reports, PDFs, or decks | summary, risks, action items, open questions | - |
-| `support-triage` | Triage support tickets or issue exports | prioritized queue with owners and next steps | `issue-triage` |
-| `api-extractor` | Crawl docs and draft an API summary plus spec | endpoint summary and draft `openapi.yaml` | `docs-to-openapi` |
-| `security-audit` | Run a structured security review with sub-agents | vulnerability report with remediation steps | - |
+15 copy-paste-ready examples in [`examples/`](examples/):
 
-Need CRM access, ticket systems, or internal APIs? Add custom tools or skills to the sandbox.
+| # | Example | What it does |
+|---|---------|--------------|
+| 01 | [hello-sandbox](examples/01-hello-sandbox/) | Minimal agent in a sandbox |
+| 02 | [code-reviewer](examples/02-code-reviewer/) | Code review with structured JSON output |
+| 03 | [competitive-analysis](examples/03-competitive-analysis/) | Market research with web crawling |
+| 04 | [structured-output](examples/04-structured-output/) | Extract TODOs with JSON schema |
+| 05 | [multi-agent-security-audit](examples/05-multi-agent-security-audit/) | Coordinated sub-agents for security review |
+| 06 | [speculative-branching](examples/06-speculative-branching/) | Multiple approaches evaluated by LLM judge |
+| 07 | [provider-vercel](examples/07-provider-vercel/) | Run on Vercel Sandbox |
+| 08 | [provider-cloudflare](examples/08-provider-cloudflare/) | Run on Cloudflare Containers |
+| 09 | [provider-docker](examples/09-provider-docker/) | Run on local Docker |
+| 10 | [fix-ci-failure](examples/10-fix-ci-failure/) | Debug CI logs and propose a fix |
+| 11 | [generate-tests](examples/11-generate-tests/) | Generate test suite with branching strategies |
+| 12 | [dependency-audit](examples/12-dependency-audit/) | Audit deps for CVEs, produce prioritized report |
+| 13 | [generate-api-docs](examples/13-generate-api-docs/) | Generate OpenAPI spec from source code |
+| 14 | [onboard-to-codebase](examples/14-onboard-to-codebase/) | Produce architecture overview of a codebase |
+| 15 | [chat-bot](examples/15-chat-bot/) | Chat bot with Slack/Discord/Telegram + HTTP gateway |
 
 ## Why Sandcaster exists
 
@@ -93,14 +109,16 @@ Sandcaster is opinionated about the missing middle:
 
 - starter to runnable project in one command
 - fresh sandbox per request with teardown by default
-- CLI, API, and Slack over the same runtime
+- CLI, API, and chat bots over the same runtime
 - config-driven behavior through `sandcaster.json`
 - multi-model support across Anthropic, OpenAI, Google, and OpenRouter
 - sub-agent orchestration with configurable tools and models per agent
+- speculative branching: run multiple approaches in parallel, pick the best with an LLM judge
 - composite sandboxes: agent-driven multi-sandbox orchestration across providers
+- session management with thread context and reconnect
 - skills system for reusable domain knowledge
 
-## Why not wire the SDK yourself?
+## Feature comparison
 
 | Capability | Sandcaster | Raw SDK | DIY runner |
 |------------|-----------|---------|------------|
@@ -112,9 +130,11 @@ Sandcaster is opinionated about the missing middle:
 | Multi-model with auto-detection | Built in | No | Custom work |
 | Sub-agent orchestration | Built in | No | Custom work |
 | Composite multi-sandbox orchestration | Built in | No | Custom work |
+| Speculative branching with LLM judge | Built in | No | Custom work |
+| Session management + reconnect | Built in | No | Custom work |
 | Skills system (SKILL.md) | Built in | No | Custom work |
 | Structured JSON output schemas | Built in | Manual wiring | Custom work |
-| Slack bot integration | Built in | No | Custom work |
+| Chat bots (Slack, Discord, Telegram) | Built in | No | Custom work |
 | Starter scaffolding with `init` | Built in | No | Custom work |
 | Rich terminal TUI (Ink) | Built in | No | Custom work |
 | Run history + JSONL store | Built in | No | Custom work |
@@ -137,6 +157,9 @@ Sandcaster is a ground-up TypeScript rewrite, not a port. Key differences:
 | Sandbox providers | E2B only | E2B, Vercel, Docker, Cloudflare |
 | Thinking levels | No | none / low / medium / high |
 | Multi-sandbox | No | Composite sandboxes with cross-provider orchestration |
+| Branching | No | Speculative branching with LLM judge evaluation |
+| Chat platforms | No | Slack, Discord, Telegram |
+| Sessions | No | Persistent sessions with thread context |
 
 ## Architecture
 
@@ -144,16 +167,20 @@ Sandcaster is a ground-up TypeScript rewrite, not a port. Key differences:
 sandcaster/
 ├── packages/
 │   ├── core               @sandcaster/core — schemas, config, sandbox orchestration, runner
-│   │   ├── providers/     E2B, Vercel, Docker, Cloudflare Containers implementations
-│   │   └── runner/        In-sandbox runner, IPC client, composite tools
-│   ├── sdk                @sandcaster/sdk — standalone TypeScript client
+│   │   ├── providers/     E2B, Vercel, Docker, Cloudflare Containers
+│   │   ├── runner/        In-sandbox runner, IPC client, composite tools
+│   │   ├── branching/     Speculative branching orchestrator + evaluators
+│   │   └── session/       Session management, conversation threading
+│   ├── sdk                @sandcaster/sdk — standalone TypeScript client (npm)
 │   ├── chat               @sandcaster/chat — unified chat bot (Slack, Discord, Telegram)
 │   ├── cloudflare-worker  Cloudflare Worker proxy for sandbox operations
 │   └── ts-config          @sandcaster/ts-config — shared TypeScript configs
 ├── apps/
 │   ├── api                @sandcaster/api — Hono REST server (SSE streaming)
-│   └── cli                @sandcaster/cli — Ink TUI with starters catalog + chat bot
-└── scripts/               E2B template management
+│   ├── cli                @sandcaster/cli — Ink TUI + chat bot (npm)
+│   └── web                @sandcaster/web — docs site (getsandcaster.com)
+├── examples/              15 copy-paste starters
+└── scripts/               E2B template + changelog sync
 ```
 
 ### Execution flow
@@ -168,6 +195,7 @@ sandcaster "prompt" -f report.pdf
   ├─ Upload runner, config, user files, skills
   ├─ Execute: node /opt/sandcaster/runner.mjs
   ├─ Stream JSON-line events → TUI / SSE
+  │   ├─ [branching] Fork N branches, evaluate with LLM judge
   │   └─ [composite] Intercept IPC requests from runner
   │       ├─ spawn_sandbox → SandboxPool creates secondary sandbox
   │       ├─ exec_in → run command in named sandbox
@@ -214,6 +242,28 @@ Auto-detection priority: `E2B_API_KEY` > `VERCEL_TOKEN` > Cloudflare env vars > 
 }
 ```
 
+## Speculative branching
+
+Run the same prompt through multiple branches in parallel and let an LLM judge pick the best result. Useful for code generation, test strategies, or any task where exploring alternatives improves quality.
+
+```json
+{
+  "branching": {
+    "enabled": true,
+    "count": 3,
+    "trigger": "always",
+    "evaluator": {
+      "type": "llm-judge",
+      "model": "sonnet"
+    }
+  }
+}
+```
+
+CLI flags: `--branches 3 --branch-trigger always --evaluator llm-judge`
+
+Each branch can use a different model or sandbox provider. The evaluator scores all branches and selects a winner with reasoning.
+
 ## Composite sandboxes
 
 Agents can dynamically spawn, coordinate, and tear down multiple sandboxes during a single run. This enables workflows like running a security scanner in one sandbox while building in another, or parallelizing work across providers.
@@ -247,32 +297,50 @@ File transfers enforce per-file (25MB) and total (50MB) size limits with path tr
 
 All secondary sandboxes are killed automatically when the run completes (secondaries first, primary last). A `SIGTERM` handler ensures cleanup on graceful shutdown.
 
-### Example config
+## Chat bots
 
-```json
-{
-  "sandboxProvider": "e2b",
-  "composite": {
-    "maxSandboxes": 5,
-    "maxTotalSpawns": 20,
-    "allowedProviders": ["e2b", "docker"]
-  }
-}
+Sandcaster includes a unified chat bot package (`@sandcaster/chat`) supporting Slack, Discord, and Telegram. Each message spawns a sandboxed agent session, with thread-based conversation tracking and automatic session management.
+
+### Zero-code (CLI)
+
+```bash
+# Set platform tokens in your environment, then:
+sandcaster chat start
 ```
 
-### Per-request override (SDK / API)
+### Production gateway
+
+For production deployments, use the HTTP gateway pattern with Hono webhook routes:
 
 ```typescript
-const events = client.query({
-  prompt: "Run security scan in a Docker sandbox, build in E2B",
-  composite: {
-    maxSandboxes: 2,
-    allowedProviders: ["e2b", "docker"]
-  }
+import { createChatBot, createChatWebhookRoutes } from "@sandcaster/chat";
+
+const { bot, pool } = await createChatBot({
+  platforms: { slack: { botToken, appToken, signingSecret } },
+  sessionTimeoutMs: 600_000,
+  allowedChannels: ["C01234ABCDE"],
+  onNewSession: async (session) => { /* wire up agent */ },
+  onSessionMessage: async (session, text) => { /* continue session */ },
 });
+
+const routes = createChatWebhookRoutes(bot);
 ```
 
+See [`examples/15-chat-bot`](examples/15-chat-bot/) for a full working example with both CLI and gateway modes.
+
+### Features
+
+- Thread-to-session mapping with per-thread mutex for message serialization
+- Thread re-engagement: rebuilds context from thread history when session expires
+- Deduplication (10-min TTL) to prevent duplicate processing
+- Access control via `allowedChannels` and `allowedUsers`
+- Event-to-text bridge streams agent output as markdown to chat
+
 ## SDK
+
+```bash
+npm install @sandcaster/sdk
+```
 
 ```typescript
 import { SandcasterClient } from "@sandcaster/sdk";
@@ -304,6 +372,7 @@ sandcaster serve --port 8000
 | `GET` | `/health` | Status and version |
 | `POST` | `/query` | Stream agent execution as SSE |
 | `GET` | `/runs` | List recent runs (limit: 1-200) |
+| `POST` | `/sessions/:sessionId/message` | Send message to an existing session |
 
 ## Configuration
 
@@ -315,10 +384,11 @@ sandcaster serve --port 8000
   "model": "sonnet",
   "maxTurns": 20,
   "timeout": 300,
-  "outputFormat": { "type": "json_schema", "schema": { ... } },
+  "outputFormat": { "type": "json_schema", "schema": { "..." : "..." } },
   "skillsDir": ".claude/skills",
   "allowedTools": ["bash", "file_read", "file_write"],
   "templateSkills": true,
+  "thinkingLevel": "medium",
   "agents": {
     "dependency-scanner": {
       "description": "Checks dependencies for known CVEs",
@@ -328,11 +398,21 @@ sandcaster serve --port 8000
   },
   "provider": "anthropic",
   "sandboxProvider": "e2b",
-  "thinkingLevel": "medium",
+  "branching": {
+    "enabled": true,
+    "count": 3,
+    "trigger": "always",
+    "evaluator": { "type": "llm-judge", "model": "sonnet" }
+  },
   "composite": {
     "maxSandboxes": 3,
     "maxTotalSpawns": 10,
     "allowedProviders": ["e2b", "docker"]
+  },
+  "chat": {
+    "sessionTimeoutMs": 600000,
+    "allowedChannels": ["C01234ABCDE"],
+    "botName": "sandcaster"
   }
 }
 ```
@@ -352,6 +432,17 @@ Use this checklist when auditing application code...
 
 Skills are injected into the agent's context and can be loaded on-demand via the `read_skill` tool.
 
+## CLI commands
+
+| Command | Description |
+|---------|-------------|
+| `sandcaster [prompt]` | Run agent with optional prompt (default command) |
+| `sandcaster serve` | Start Hono API server |
+| `sandcaster init [starter]` | Scaffold a starter project |
+| `sandcaster chat start` | Start chat bot (Slack/Discord/Telegram) |
+| `sandcaster session <id>` | Interact with an existing session |
+| `sandcaster templates` | List or push E2B sandbox templates |
+
 ## Development
 
 ```bash
@@ -361,7 +452,11 @@ bunx turbo test          # Run all tests
 bunx turbo lint          # Lint all packages (Biome)
 ```
 
+Published packages use [Changesets](https://github.com/changesets/changesets) for versioning. CI publishes `@sandcaster/sdk` and `@sandcaster/cli` to npm with provenance on every release.
+
 ## Community
+
+Docs and changelog at [getsandcaster.com](https://getsandcaster.com).
 
 If Sandcaster saves you runner plumbing, please star the repo.
 


### PR DESCRIPTION
## Summary
- Add npm badges for `@sandcaster/sdk` and `@sandcaster/cli`
- Document chat bot support (Slack, Discord, Telegram) with zero-code CLI and production gateway examples
- Add speculative branching section with config and CLI flags
- Add session management, CLI commands table, and all 15 examples
- Add npm install path alongside from-source instructions
- Link to getsandcaster.com and note Changesets-based release pipeline
- Update architecture diagram, feature comparison, and Sandstorm diff tables

## Test plan
- [ ] Verify all internal links resolve (examples, LICENSE)
- [ ] Confirm npm badge URLs are correct
- [ ] Check code blocks render properly on GitHub