### PR TITLE
fix(api): enforce minimum API key length in auth middleware

### DIFF
--- a/apps/api/src/__tests__/middleware/auth.test.ts
+++ b/apps/api/src/__tests__/middleware/auth.test.ts
@@ -38,6 +38,20 @@ describe("bearer auth middleware", () => {
 		const res = await app.request("/runs");
 		expect(res.status).toBe(401);
 	});
+
+	test("throws when apiKey is shorter than MIN_KEY_LENGTH", () => {
+		expect(() => createApp({ apiKey: "too-short" })).toThrow(
+			/at least 32 characters/,
+		);
+	});
+
+	test("throws when apiKey is 1 character", () => {
+		expect(() => createApp({ apiKey: "x" })).toThrow(/at least 32 characters/);
+	});
+
+	test("accepts apiKey exactly at MIN_KEY_LENGTH", () => {
+		expect(() => createApp({ apiKey: "a".repeat(32) })).not.toThrow();
+	});
 });
 
 describe("request ID middleware", () => {

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -1,10 +1,20 @@
-import { validateBearerToken } from "@sandcaster/core";
+import {
+	MIN_KEY_LENGTH,
+	validateBearerToken,
+	validateKeyLength,
+} from "@sandcaster/core";
 import type { MiddlewareHandler } from "hono";
 import { bearerAuth } from "hono/bearer-auth";
 
 const PUBLIC_PATHS = new Set(["/health"]);
 
 export function createAuthMiddleware(apiKey: string): MiddlewareHandler {
+	if (!validateKeyLength(apiKey)) {
+		throw new Error(
+			`SANDCASTER_API_KEY must be at least ${MIN_KEY_LENGTH} characters (got ${apiKey.length})`,
+		);
+	}
+
 	const auth = bearerAuth({
 		verifyToken: (token) => validateBearerToken(token, [apiKey]),
 	});


### PR DESCRIPTION
## Summary
- Call `validateKeyLength()` in `createAuthMiddleware()` so insecurely short API keys are rejected at startup with a clear error message
- The guard function existed but was never integrated into the middleware

## Test plan
- [x] Added tests: throws when key is too short (1 char, "too-short")
- [x] Added test: accepts key at exactly MIN_KEY_LENGTH (32)
- [x] Existing auth tests still pass

Closes #32