### PR TITLE
fix(core): validate nested config sub-fields individually

### DIFF
--- a/packages/core/src/__tests__/config.test.ts
+++ b/packages/core/src/__tests__/config.test.ts
@@ -198,6 +198,45 @@ describe("loadConfig", () => {
 	});
 
 	// -------------------------------------------------------------------------
+	// Nested object partial tolerance
+	// -------------------------------------------------------------------------
+
+	it("strips invalid nested sub-field but preserves valid siblings in composite", async () => {
+		writeConfig(tmpDir, {
+			composite: {
+				maxSandboxes: 0, // invalid: gte(1)
+				allowedProviders: ["e2b"], // valid
+			},
+		});
+		const loadConfig = await getLoadConfig();
+		const result = loadConfig(tmpDir);
+
+		// allowedProviders should be preserved, maxSandboxes stripped (gets default)
+		expect(result?.composite?.allowedProviders).toEqual(["e2b"]);
+		expect(result?.composite?.maxSandboxes).toBe(3); // default
+		expect(warnSpy).toHaveBeenCalled();
+		const warnMsg = warnSpy.mock.calls
+			.map((args) => String(args[0]))
+			.join("\n");
+		expect(warnMsg).toContain("maxSandboxes");
+	});
+
+	it("preserves entire composite when all sub-fields are valid", async () => {
+		writeConfig(tmpDir, {
+			composite: {
+				maxSandboxes: 5,
+				allowedProviders: ["e2b"],
+			},
+		});
+		const loadConfig = await getLoadConfig();
+		const result = loadConfig(tmpDir);
+
+		expect(result?.composite?.maxSandboxes).toBe(5);
+		expect(result?.composite?.allowedProviders).toEqual(["e2b"]);
+		expect(warnSpy).not.toHaveBeenCalled();
+	});
+
+	// -------------------------------------------------------------------------
 	// Cache cleared when file is deleted
 	// -------------------------------------------------------------------------
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,5 +1,6 @@
 import { readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
+import type { z } from "zod";
 import type { SandcasterConfig } from "./schemas.js";
 import { SandcasterConfigSchema } from "./schemas.js";
 
@@ -21,8 +22,35 @@ const KNOWN_FIELDS = new Set(Object.keys(SandcasterConfigSchema.shape));
 // ---------------------------------------------------------------------------
 
 /**
+ * Unwrap ZodOptional to get the inner schema (Zod v4 introspection).
+ */
+function unwrapOptional(schema: z.ZodTypeAny): z.ZodTypeAny {
+	// biome-ignore lint/suspicious/noExplicitAny: Zod v4 internal introspection
+	const def = (schema as any)._zod?.def;
+	if (def?.type === "optional") {
+		return def.innerType;
+	}
+	return schema;
+}
+
+/**
+ * If the schema is an object type, return its shape. Otherwise null.
+ */
+function getObjectShape(
+	schema: z.ZodTypeAny,
+): Record<string, z.ZodTypeAny> | null {
+	// biome-ignore lint/suspicious/noExplicitAny: Zod v4 internal introspection
+	const def = (schema as any)._zod?.def;
+	if (def?.type === "object" && "shape" in schema) {
+		return (schema as unknown as { shape: Record<string, z.ZodTypeAny> }).shape;
+	}
+	return null;
+}
+
+/**
  * Validates a single field value against its Zod schema shape.
- * Returns the parsed value if valid, or undefined + a warning if not.
+ * For nested object fields, validates sub-fields individually so one invalid
+ * sub-field doesn't discard valid siblings.
  */
 function validateField(
 	key: string,
@@ -39,6 +67,44 @@ function validateField(
 	if (result.success) {
 		return { ok: true, value: result.data };
 	}
+
+	// For nested objects, try partial validation of sub-fields
+	const inner = unwrapOptional(fieldSchema);
+	const shape = getObjectShape(inner);
+	if (
+		shape &&
+		value !== null &&
+		typeof value === "object" &&
+		!Array.isArray(value)
+	) {
+		const partial: Record<string, unknown> = {};
+		for (const [subKey, subValue] of Object.entries(
+			value as Record<string, unknown>,
+		)) {
+			const subSchema = shape[subKey];
+			if (!subSchema) {
+				console.warn(
+					`sandcaster.json: field "${key}.${subKey}" unknown — ignoring`,
+				);
+				continue;
+			}
+			const subResult = subSchema.safeParse(subValue);
+			if (subResult.success) {
+				partial[subKey] = subResult.data;
+			} else {
+				const reason = subResult.error.issues[0]?.message ?? "invalid value";
+				console.warn(
+					`sandcaster.json: field "${key}.${subKey}" invalid (${reason}) — ignoring`,
+				);
+			}
+		}
+		// Re-parse the partial object so defaults fill in
+		const reparsed = fieldSchema.safeParse(partial);
+		if (reparsed.success) {
+			return { ok: true, value: reparsed.data };
+		}
+	}
+
 	const reason = result.error.issues[0]?.message ?? "invalid value";
 	return { ok: false, reason };
 }


### PR DESCRIPTION
## Summary
- When a nested object field (e.g. `composite`) had one invalid sub-field, the entire object was dropped, silently losing valid siblings like `allowedProviders`
- Now sub-fields are validated individually — only invalid ones are stripped, valid ones preserved, and defaults fill in for missing fields

## Test plan
- [x] Added test: invalid `maxSandboxes: 0` strips only that field, preserves `allowedProviders: ["e2b"]`
- [x] Added test: fully valid composite object is preserved as-is
- [x] All existing config tests still pass (12/12)

Closes #33