### PR TITLE
fix(cloudflare): decode base64 content for binary file reads

### DIFF
--- a/packages/cloudflare-worker/src/index.ts
+++ b/packages/cloudflare-worker/src/index.ts
@@ -102,7 +102,10 @@ app.get("/sandbox/:id/files/read", async (c) => {
 	const sandbox = getSandbox(c.env.Sandbox, sessionId);
 	const file = await sandbox.readFile(path);
 
-	return c.json({ content: file.content });
+	return c.json({
+		content: file.content,
+		encoding: file.encoding,
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/__tests__/providers/cloudflare.test.ts
+++ b/packages/core/src/__tests__/providers/cloudflare.test.ts
@@ -382,6 +382,29 @@ describe("createCloudflareProvider", () => {
 		expect(content).toBeInstanceOf(Uint8Array);
 	});
 
+	it("files.read decodes base64 content correctly for binary files", async () => {
+		setupSuccessfulCreate();
+		const originalBytes = new Uint8Array([0, 255, 128, 42, 1]);
+		const base64Content = Buffer.from(originalBytes).toString("base64");
+		mockFetch.mockResolvedValueOnce(
+			makeJsonResponse({ content: base64Content, encoding: "base64" }),
+		);
+
+		const provider = createCloudflareProvider();
+		const result = await provider.create({
+			metadata: { workerUrl: WORKER_URL },
+		});
+		expect(result.ok).toBe(true);
+		if (!result.ok) throw new Error("unreachable");
+
+		const content = await result.instance.files.read("/workspace/binary.bin", {
+			format: "bytes",
+		});
+
+		expect(content).toBeInstanceOf(Uint8Array);
+		expect(content).toEqual(originalBytes);
+	});
+
 	// -------------------------------------------------------------------------
 	// commands.run
 	// -------------------------------------------------------------------------

--- a/packages/core/src/providers/cloudflare.ts
+++ b/packages/core/src/providers/cloudflare.ts
@@ -214,8 +214,14 @@ export function createCloudflareProvider(): SandboxProvider {
 									: "SANDBOX_ERROR",
 							);
 						}
-						const { content } = (await resp.json()) as { content: string };
+						const { content, encoding } = (await resp.json()) as {
+							content: string;
+							encoding?: string;
+						};
 						if (opts?.format === "bytes") {
+							if (encoding === "base64") {
+								return new Uint8Array(Buffer.from(content, "base64"));
+							}
 							return new TextEncoder().encode(content);
 						}
 						return content;


### PR DESCRIPTION
## Summary
- Worker now includes `encoding` metadata in the file read response
- Provider decodes base64 when `encoding === "base64"` and `format: "bytes"`, instead of using `TextEncoder`
- Fixes binary round-trip corruption (write Uint8Array → read with format bytes)

## Test plan
- [x] Added test: binary bytes round-trip via base64 encoding/decoding
- [x] All existing cloudflare provider tests pass (28/28)

Closes #34