### PR TITLE
fix(sdk): abort fetch on early SSE iterator exit

### DIFF
--- a/packages/sdk/src/__tests__/client.test.ts
+++ b/packages/sdk/src/__tests__/client.test.ts
@@ -351,6 +351,45 @@ describe("SandcasterClient", () => {
 		});
 	});
 
+	describe("early break aborts fetch", () => {
+		it("aborts the underlying fetch when consumer breaks from for-await", async () => {
+			const encoder = new TextEncoder();
+			let pullCount = 0;
+
+			const body = new ReadableStream<Uint8Array>({
+				pull(ctrl) {
+					pullCount++;
+					ctrl.enqueue(
+						encoder.encode(
+							`data: ${JSON.stringify({ type: "system", content: `event-${pullCount}` })}\n\n`,
+						),
+					);
+					// Never close — stream keeps producing
+				},
+			});
+
+			let capturedSignal: AbortSignal | undefined;
+			fetchMock.mockImplementation((_url: string, init: RequestInit) => {
+				capturedSignal = init.signal;
+				return Promise.resolve(
+					new Response(body, {
+						status: 200,
+						headers: { "Content-Type": "text/event-stream" },
+					}),
+				);
+			});
+
+			const client = new SandcasterClient({ baseUrl: "http://localhost:3000" });
+
+			for await (const _event of client.query({ prompt: "test" })) {
+				break; // early exit
+			}
+
+			// The abort signal should have been triggered by cleanup
+			expect(capturedSignal?.aborted).toBe(true);
+		});
+	});
+
 	describe("dispose (Symbol.asyncDispose)", () => {
 		it("aborts in-flight query() streams on dispose", async () => {
 			// Use a stream that never ends — we dispose before it finishes

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -62,6 +62,7 @@ export class SandcasterClient {
 				}
 
 				const cleanup = () => {
+					controller.abort();
 					self.#activeControllers.delete(controller);
 					if (abortHandler) {
 						options?.signal?.removeEventListener("abort", abortHandler);


### PR DESCRIPTION
## Summary
- Added `controller.abort()` to the `cleanup()` function in `#makeSSEIterable` so breaking from a `for-await` loop properly cancels the underlying fetch request
- Previously only bookkeeping was cleaned up, leaving HTTP connections open

## Test plan
- [x] Added test: verify `AbortSignal.aborted` is `true` after breaking from iteration
- [x] All existing SDK client tests pass (18/18)

Closes #35