### PR TITLE
fix(sdk,cli): cancel stream reader before releasing lock on early exit

### DIFF
--- a/apps/cli/src/commands/session.ts
+++ b/apps/cli/src/commands/session.ts
@@ -126,6 +126,7 @@ export async function executeSessionAttach(
 			}
 		}
 	} finally {
+		await reader.cancel();
 		reader.releaseLock();
 	}
 }

--- a/packages/sdk/src/__tests__/stream.test.ts
+++ b/packages/sdk/src/__tests__/stream.test.ts
@@ -175,6 +175,40 @@ describe("parseSSEStream", () => {
 		expect(collected[0]).toEqual({ type: "system", content: "first" });
 	});
 
+	it("cancels the underlying stream when breaking early from iteration", async () => {
+		const encoder = new TextEncoder();
+		const cancelPromise = new Promise<void>((resolve) => {
+			const body = new ReadableStream<Uint8Array>({
+				pull(ctrl) {
+					ctrl.enqueue(
+						encoder.encode(
+							`data: ${JSON.stringify({ type: "system", content: "event" })}\n\n`,
+						),
+					);
+				},
+				cancel() {
+					resolve();
+				},
+			});
+
+			(async () => {
+				for await (const _event of parseSSEStream(body)) {
+					break;
+				}
+			})();
+		});
+
+		// Cancel should propagate within a reasonable time
+		await expect(
+			Promise.race([
+				cancelPromise,
+				new Promise((_, reject) =>
+					setTimeout(() => reject(new Error("stream not cancelled")), 1000),
+				),
+			]),
+		).resolves.toBeUndefined();
+	});
+
 	it("yields error events rather than throwing them (FR-2)", async () => {
 		const body = createSSEStream({
 			type: "error",

--- a/packages/sdk/src/stream.ts
+++ b/packages/sdk/src/stream.ts
@@ -81,6 +81,7 @@ export async function* parseSSEStream(
 			}
 		}
 	} finally {
+		await reader.cancel();
 		reader.releaseLock();
 	}
 }


### PR DESCRIPTION
## Summary
- Call `await reader.cancel()` before `reader.releaseLock()` in `parseSSEStream` and CLI session handler
- This properly closes the HTTP connection when consumers stop iterating early

## Test plan
- [x] Added test: stream cancel callback fires when breaking from iteration
- [x] All existing stream tests pass (10/10)

Closes #36