### PR TITLE
fix(core): store tool_use/tool_result events in session history

### DIFF
--- a/packages/core/src/__tests__/session/session-manager.test.ts
+++ b/packages/core/src/__tests__/session/session-manager.test.ts
@@ -891,4 +891,59 @@ describe("SessionManager", () => {
 		const active = manager.getActiveSession(sessionId);
 		expect(active!.session.status).not.toBe("running");
 	});
+
+	// -------------------------------------------------------------------------
+	// Tool call events stored in session history
+	// -------------------------------------------------------------------------
+
+	it("stores tool_use and tool_result events in session history with isToolCall flag", async () => {
+		const sandbox = createFakeSandbox();
+		const store = createFakeStore();
+		const agentEvents: SandcasterEvent[] = [
+			{ type: "tool_use", toolName: "bash", content: "ls -la" },
+			{
+				type: "tool_result",
+				toolName: "bash",
+				content: "file1.txt\nfile2.txt",
+				isError: false,
+			},
+			{ type: "assistant", content: "I found two files." },
+			{
+				type: "result",
+				content: "Done",
+				costUsd: 0.01,
+				numTurns: 1,
+				durationSecs: 1,
+			},
+		];
+		const manager = new SessionManager({
+			store,
+			sandboxFactory: vi.fn().mockResolvedValue(sandbox),
+			runAgent: createFakeRunAgent(agentEvents),
+		});
+
+		const { sessionId, events } = await manager.createSession(
+			makeSessionCreateRequest({ prompt: "list files" }),
+		);
+		await collectEvents(events);
+
+		const activeSession = manager.getActiveSession(sessionId);
+		expect(activeSession).toBeDefined();
+
+		const history = activeSession!.history;
+		// Should have: user, tool_use, tool_result, assistant
+		expect(history.length).toBeGreaterThanOrEqual(4);
+
+		const toolUseTurn = history.find(
+			(t) => t.role === "assistant" && t.isToolCall,
+		);
+		const toolResultTurn = history.find(
+			(t) => t.role === "user" && t.isToolCall,
+		);
+
+		expect(toolUseTurn).toBeDefined();
+		expect(toolUseTurn!.content).toContain("bash");
+		expect(toolResultTurn).toBeDefined();
+		expect(toolResultTurn!.content).toContain("bash");
+	});
 });

--- a/packages/core/src/session/session-manager.ts
+++ b/packages/core/src/session/session-manager.ts
@@ -649,6 +649,28 @@ export class SessionManager {
 					if (event.type === "assistant") {
 						assistantContent += event.content;
 					}
+					if (event.type === "tool_use") {
+						addTurn(
+							activeSession.history,
+							{
+								role: "assistant",
+								content: `Tool call (${event.toolName}): ${event.content}`,
+								isToolCall: true,
+							},
+							maxHistoryTurns,
+						);
+					}
+					if (event.type === "tool_result") {
+						addTurn(
+							activeSession.history,
+							{
+								role: "user",
+								content: `Tool result (${event.toolName}): ${event.content}`,
+								isToolCall: true,
+							},
+							maxHistoryTurns,
+						);
+					}
 					if (event.type === "result") {
 						costUsd = event.costUsd;
 						numTurns = event.numTurns;


### PR DESCRIPTION
## Summary
- Store `tool_use` and `tool_result` events in `activeSession.history` with `isToolCall: true` flag
- This provides tool outputs in the LLM context for follow-up turns and enables the existing atomic trimming logic in `addTurn()`

## Test plan
- [x] Added test: tool_use and tool_result turns appear in history with correct role and isToolCall flag
- [x] All existing session-manager tests pass (22/22)

Closes #37