### PR TITLE
fix(core): reject file paths that normalize to the same target

### DIFF
--- a/packages/core/src/__tests__/schemas.test.ts
+++ b/packages/core/src/__tests__/schemas.test.ts
@@ -119,6 +119,20 @@ describe("QueryRequestSchema", () => {
 		expect(result.success).toBe(false);
 	});
 
+	it("rejects files with paths that normalize to the same target", () => {
+		const result = QueryRequestSchema.safeParse({
+			prompt: "test",
+			files: {
+				"config.json": "first",
+				"./config.json": "second",
+			},
+		});
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues[0].message).toContain("config.json");
+		}
+	});
+
 	it("rejects invalid extra agent names (spaces/special chars)", () => {
 		const result = QueryRequestSchema.safeParse({
 			prompt: "test",

--- a/packages/core/src/schemas.ts
+++ b/packages/core/src/schemas.ts
@@ -98,6 +98,21 @@ const filesSchema = z
 			}
 		}
 
+		// Detect paths that normalize to the same target
+		const seen = new Map<string, string>();
+		for (const path of keys) {
+			const norm = normalizePosixPath(path) as string;
+			const prev = seen.get(norm);
+			if (prev !== undefined) {
+				ctx.addIssue({
+					code: "custom",
+					message: `Paths "${prev}" and "${path}" both resolve to "${norm}". Remove the duplicate.`,
+				});
+				return;
+			}
+			seen.set(norm, path);
+		}
+
 		if (keys.length > 20) {
 			ctx.addIssue({
 				code: "custom",


### PR DESCRIPTION
## Summary
- Detect and reject file paths that normalize to the same target (e.g. `config.json` and `./config.json`)
- Previously, the transform silently used last-write-wins semantics, dropping earlier content

## Test plan
- [x] Added test: colliding paths rejected with clear error message
- [x] All existing schema tests pass (112/112)

Closes #39