### PR TITLE
fix(core): use sh -c for Vercel provider command execution

### DIFF
--- a/packages/core/src/__tests__/providers/vercel.test.ts
+++ b/packages/core/src/__tests__/providers/vercel.test.ts
@@ -389,10 +389,29 @@ describe("createVercelProvider", () => {
 		if (!result.ok) throw new Error("unreachable");
 
 		const cmdRes = await result.instance.commands.run("echo hello");
-		expect(runCommand).toHaveBeenCalledWith("echo", ["hello"]);
+		expect(runCommand).toHaveBeenCalledWith("sh", ["-c", "echo hello"]);
 		expect(cmdRes.exitCode).toBe(0);
 		expect(cmdRes.stdout).toBe("hello\n");
 		expect(cmdRes.stderr).toBe("warn\n");
+	});
+
+	it("commands.run passes commands with pipes/quotes through sh -c", async () => {
+		const cmdResult = makeCommandResult({
+			exitCode: 0,
+			logs: [{ stream: "stdout", data: "file1.txt\n" }],
+		});
+		const runCommand = vi.fn().mockResolvedValue(cmdResult);
+		const fakeSbx = makeVercelSandbox({ runCommand });
+		mockSandboxCreate.mockResolvedValue(fakeSbx);
+
+		const provider = createVercelProvider();
+		const result = await provider.create({});
+		expect(result.ok).toBe(true);
+		if (!result.ok) throw new Error("unreachable");
+
+		const cmd = 'find /dir -type f | sed "s|/dir/||"';
+		await result.instance.commands.run(cmd);
+		expect(runCommand).toHaveBeenCalledWith("sh", ["-c", cmd]);
 	});
 
 	it("commands.run returns non-zero exit code without throwing", async () => {

--- a/packages/core/src/providers/vercel.ts
+++ b/packages/core/src/providers/vercel.ts
@@ -204,9 +204,8 @@ export function createVercelProvider(): SandboxProvider {
 							cmd: string,
 							opts?: CommandOptions,
 						): Promise<{ stdout: string; stderr: string; exitCode: number }> {
-							// Vercel SDK uses fork/exec — split command into binary + args
-							const parts = cmd.split(/\s+/);
-							const command = await sbx.runCommand(parts[0], parts.slice(1));
+							// Wrap with sh -c so shell operators (pipes, redirects, quotes) work
+							const command = await sbx.runCommand("sh", ["-c", cmd]);
 							const { stdout, stderr } = await collectLogs(command.logs, opts);
 							return { stdout, stderr, exitCode: command.exitCode };
 						},


### PR DESCRIPTION
## Summary
- Replace naive `cmd.split(/\s+/)` with `sbx.runCommand("sh", ["-c", cmd])` so shell operators (pipes, redirects, quotes) work correctly
- Matches the Docker provider's existing approach

## Test plan
- [x] Added test: commands with pipes/quotes passed through `sh -c`
- [x] Updated existing test expectations for the new calling convention
- [x] All vercel provider tests pass (27/27)

Closes #40