### PR TITLE
fix(release): create PR for changelog sync instead of direct push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,18 +62,18 @@ jobs:
         if: steps.changesets.outputs.published == 'true'
         env:
           PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        run: bun run scripts/sync-changelog-to-web.ts
 
-          bun run scripts/sync-changelog-to-web.ts
-
-          git add apps/web/src/content/changelog/
-          git diff --staged --quiet && exit 0
-
-          git commit -m "docs: sync changelog to website"
-          git pull --rebase origin main
-          git push
+      - name: Create changelog PR
+        if: steps.changesets.outputs.published == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "docs: sync changelog to website"
+          branch: docs/sync-changelog
+          title: "docs: sync changelog to website"
+          body: "Auto-generated changelog entries from release."
+          add-paths: apps/web/src/content/changelog/
+          delete-branch: true
 
       - name: Trigger website deploy
         if: steps.changesets.outputs.published == 'true'


### PR DESCRIPTION
## Summary

Follow-up to #57. The npm publish now succeeds, but the changelog sync step fails because branch protection rejects direct pushes to `main`.

- Replace manual `git commit && git push` with `peter-evans/create-pull-request@v7`
- Changelog entries are now opened as a PR (`docs/sync-changelog` branch) instead of pushed directly

## Test plan

- [ ] Merge and trigger a release — verify a changelog PR is auto-created
- [ ] Verify website deploy still triggers after publish