### PR TITLE
fix(release): use Node 24 for npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,11 +30,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
 
       - uses: actions/cache@v4
         with:


### PR DESCRIPTION
## Summary

Follow-up to #58. `npm install -g npm@latest` fails on Node 22 with `MODULE_NOT_FOUND` (npm 10.x can't self-upgrade cleanly).

- Switch from Node 22 to Node 24 in the release workflow
- Node 24 ships with npm 11.x which supports OIDC publish auth natively
- Remove the broken `npm install -g npm@latest` step
- Node is only used for `npm publish` — the project uses Bun for everything else

## Test plan

- [ ] Verify `npm --version` shows 11.x+ in CI logs
- [ ] Verify npm publish succeeds via OIDC