### PR TITLE
fix(ci): add security-events:write for zizmor SARIF upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  security-events: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

CI failed on main after merging #61 — the `zizmor-action` uploads SARIF to GitHub Code Scanning, which requires `security-events: write` permission. The workflow only had `contents: read`.

## Test plan

- [ ] CI passes — Lint GitHub Actions job completes successfully