### PR TITLE
fix(ipc): prevent payload from overriding correlation id

### DIFF
--- a/packages/core/src/__tests__/runner/ipc-client.test.ts
+++ b/packages/core/src/__tests__/runner/ipc-client.test.ts
@@ -121,6 +121,23 @@ describe("IpcClient.request — emitting", () => {
 		expect(parsed.template).toBe("tmpl");
 	});
 
+	it("does not allow payload to override id or nonce", async () => {
+		const emittedLines: string[] = [];
+		const response = makeResponse({ id: "stub" });
+		const readFile = vi.fn().mockResolvedValueOnce(JSON.stringify(response));
+		const deps = makeDeps({
+			emit: (line) => emittedLines.push(line),
+			readFile,
+		});
+		const client = new IpcClient(deps, makeConfig({ nonce: "real-nonce" }));
+
+		await client.request("exec", { id: "evil-id", nonce: "evil-nonce", name: "worker", command: "ls" });
+
+		const parsed = JSON.parse(emittedLines[0]);
+		expect(parsed.nonce).toBe("real-nonce");
+		expect(parsed.id).not.toBe("evil-id");
+	});
+
 	it("emits a request with a unique id each call", async () => {
 		const emittedLines: string[] = [];
 		// readFile: for each call, return a matching response

--- a/packages/core/src/__tests__/runner/ipc-client.test.ts
+++ b/packages/core/src/__tests__/runner/ipc-client.test.ts
@@ -131,7 +131,12 @@ describe("IpcClient.request — emitting", () => {
 		});
 		const client = new IpcClient(deps, makeConfig({ nonce: "real-nonce" }));
 
-		await client.request("exec", { id: "evil-id", nonce: "evil-nonce", name: "worker", command: "ls" });
+		await client.request("exec", {
+			id: "evil-id",
+			nonce: "evil-nonce",
+			name: "worker",
+			command: "ls",
+		});
 
 		const parsed = JSON.parse(emittedLines[0]);
 		expect(parsed.nonce).toBe("real-nonce");

--- a/packages/core/src/runner/ipc-client.ts
+++ b/packages/core/src/runner/ipc-client.ts
@@ -27,10 +27,10 @@ export class IpcClient {
 		const id = crypto.randomUUID();
 		const message = {
 			type: "composite_request",
+			...payload,
 			id,
 			nonce: this.config.nonce,
 			action,
-			...payload,
 		};
 
 		this.deps.emit(JSON.stringify(message));


### PR DESCRIPTION
## Summary
- Reorder object spread in `IpcClient.request()` so `id` and `nonce` fields cannot be overridden by the payload parameter
- Add test verifying payload keys don't clobber correlation id or nonce

Closes #72

## Test plan
- [ ] New unit test: payload with `id`/`nonce` keys does not override generated values
- [ ] All existing IPC client tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)