### PR TITLE
fix(core): prevent trimming from dropping unrelated turns

### DIFF
--- a/packages/core/src/__tests__/session/conversation.test.ts
+++ b/packages/core/src/__tests__/session/conversation.test.ts
@@ -49,6 +49,20 @@ describe("addTurn", () => {
 		expect(history[1].content).toBe("next");
 	});
 
+	it("does not remove an unrelated turn when oldest is an unpaired tool_result", () => {
+		const history: ConversationTurn[] = [
+			{ role: "user", content: "tool_result: ok", isToolCall: true },
+			{ role: "assistant", content: "important response" },
+			{ role: "user", content: "follow up" },
+		];
+		addTurn(history, { role: "assistant", content: "new response" }, 3);
+		// Should remove only the unpaired tool_result, not the important response
+		expect(history).toHaveLength(3);
+		expect(history[0].content).toBe("important response");
+		expect(history[1].content).toBe("follow up");
+		expect(history[2].content).toBe("new response");
+	});
+
 	it("does not split a tool call pair when trimming", () => {
 		const history: ConversationTurn[] = [
 			{ role: "user", content: "regular" },

--- a/packages/core/src/session/conversation.ts
+++ b/packages/core/src/session/conversation.ts
@@ -15,7 +15,7 @@ export function addTurn(
 	history.push(turn);
 
 	while (history.length > maxTurns) {
-		if (history[0]?.isToolCall) {
+		if (history[0]?.isToolCall && history[1]?.isToolCall) {
 			// Remove both turns of the tool call pair
 			history.splice(0, 2);
 		} else {


### PR DESCRIPTION
## Summary
- Fix `addTurn` to check both entries of a tool call pair before removing 2 entries
- When only the first entry is a tool call (unpaired), remove just that one entry
- Prevents dropping unrelated conversation turns during history trimming

Closes #71

## Test plan
- [x] New test: unpaired tool_result at index 0 only removes 1 entry
- [x] Existing paired tool call test still removes both entries
- [x] All conversation tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)