### PR TITLE
fix(core): sum cost across all turns in agent_end

### DIFF
--- a/packages/core/src/__tests__/runner/event-translator.test.ts
+++ b/packages/core/src/__tests__/runner/event-translator.test.ts
@@ -176,6 +176,68 @@ describe("createEventTranslator", () => {
 			expect(resultEvent.numTurns).toBe(1);
 		});
 
+		it("sums costUsd across all assistant messages in multi-turn run", () => {
+			const translator = createEventTranslator();
+			const messages = [
+				makeAssistantMessage({
+					usage: {
+						input: 100,
+						output: 50,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 150,
+						cost: {
+							input: 0.001,
+							output: 0.002,
+							cacheRead: 0,
+							cacheWrite: 0,
+							total: 0.01,
+						},
+					},
+				}),
+				makeAssistantMessage({
+					usage: {
+						input: 200,
+						output: 100,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 300,
+						cost: {
+							input: 0.002,
+							output: 0.004,
+							cacheRead: 0,
+							cacheWrite: 0,
+							total: 0.02,
+						},
+					},
+				}),
+				makeAssistantMessage({
+					usage: {
+						input: 300,
+						output: 150,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 450,
+						cost: {
+							input: 0.003,
+							output: 0.006,
+							cacheRead: 0,
+							cacheWrite: 0,
+							total: 0.03,
+						},
+					},
+				}),
+			];
+			const events = translator.translate({
+				type: "agent_end",
+				messages,
+			});
+
+			expect(events).toHaveLength(1);
+			const result = events[0] as { costUsd: number };
+			expect(result.costUsd).toBeCloseTo(0.06);
+		});
+
 		it("counts all assistant messages for numTurns", () => {
 			const translator = createEventTranslator();
 			const messages = [

--- a/packages/core/src/runner/event-translator.ts
+++ b/packages/core/src/runner/event-translator.ts
@@ -112,7 +112,16 @@ export function createEventTranslator(): {
 					return [];
 				}
 
-				const costUsd = last.usage?.cost?.total;
+				// Sum cost across all assistant messages
+				let totalCost = 0;
+				let hasCost = false;
+				for (const msg of assistantMessages) {
+					if (msg.usage?.cost?.total !== undefined) {
+						totalCost += msg.usage.cost.total;
+						hasCost = true;
+					}
+				}
+				const costUsd = hasCost ? totalCost : undefined;
 				const model = last.model;
 				const numTurns = assistantMessages.length;
 


### PR DESCRIPTION
## Summary
- Fix cost reporting to sum `usage.cost.total` across all assistant messages instead of only reading the last one
- Multi-turn agent runs now report accurate total cost

Closes #68

## Test plan
- [x] New test: 3-turn agent run reports summed cost (0.01 + 0.02 + 0.03 = 0.06)
- [x] Existing single-turn cost test still passes
- [x] All event translator tests pass (36/36)
- [x] Full test suite passes (883 core tests, 1347 total across all packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)