### PR TITLE
fix(e2b): return exitCode on non-zero exit instead of throwing

### DIFF
--- a/packages/core/src/__tests__/providers/e2b.test.ts
+++ b/packages/core/src/__tests__/providers/e2b.test.ts
@@ -261,6 +261,42 @@ describe("createE2BProvider", () => {
 		});
 	});
 
+	it("returns exitCode instead of throwing when command exits non-zero", async () => {
+		const nonZeroError = Object.assign(new Error("Command failed"), {
+			stdout: "partial output",
+			stderr: "error message",
+			exitCode: 1,
+		});
+		const commandsRun = vi.fn().mockRejectedValueOnce(nonZeroError);
+		const fakeSbx = makeE2BSandbox({ commandsRun });
+		createMock.mockResolvedValue(fakeSbx);
+
+		const provider = createE2BProvider();
+		const result = await provider.create({ apiKey: "test-key" });
+		if (!result.ok) throw new Error("unreachable");
+
+		const cmdResult = await result.instance.commands.run("exit 1");
+		expect(cmdResult.exitCode).toBe(1);
+		expect(cmdResult.stdout).toBe("partial output");
+		expect(cmdResult.stderr).toBe("error message");
+	});
+
+	it("rethrows errors without exitCode property", async () => {
+		const commandsRun = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("Network error"));
+		const fakeSbx = makeE2BSandbox({ commandsRun });
+		createMock.mockResolvedValue(fakeSbx);
+
+		const provider = createE2BProvider();
+		const result = await provider.create({ apiKey: "test-key" });
+		if (!result.ok) throw new Error("unreachable");
+
+		await expect(result.instance.commands.run("ls")).rejects.toThrow(
+			"Network error",
+		);
+	});
+
 	it("instance.commands.run maps onStdout/onStderr/timeoutMs from opts", async () => {
 		const commandsRun = vi
 			.fn()

--- a/packages/core/src/providers/e2b.ts
+++ b/packages/core/src/providers/e2b.ts
@@ -136,7 +136,7 @@ export function createE2BProvider(): SandboxProvider {
 						},
 					},
 					commands: {
-						run(
+						async run(
 							cmd: string,
 							opts?: CommandOptions,
 						): Promise<{
@@ -144,11 +144,29 @@ export function createE2BProvider(): SandboxProvider {
 							stderr: string;
 							exitCode: number;
 						}> {
-							return sbx.commands.run(cmd, opts as any) as Promise<{
-								stdout: string;
-								stderr: string;
-								exitCode: number;
-							}>;
+							try {
+								const result = await sbx.commands.run(cmd, opts as any);
+								return result as {
+									stdout: string;
+									stderr: string;
+									exitCode: number;
+								};
+							} catch (err) {
+								// E2B throws on non-zero exit — extract result if available
+								const maybeResult = err as {
+									stdout?: string;
+									stderr?: string;
+									exitCode?: number;
+								};
+								if (typeof maybeResult.exitCode === "number") {
+									return {
+										stdout: maybeResult.stdout ?? "",
+										stderr: maybeResult.stderr ?? "",
+										exitCode: maybeResult.exitCode,
+									};
+								}
+								throw err;
+							}
 						},
 					},
 					async kill(): Promise<void> {


### PR DESCRIPTION
## Summary
- Wrap E2B `commands.run` to catch non-zero exit errors and extract stdout/stderr/exitCode
- Unknown errors (without exitCode) are still rethrown
- Commands that fail (build errors, test failures) now return exit code for caller to handle

Closes #65

## Test plan
- [ ] New test: non-zero exit returns result with exitCode instead of throwing
- [ ] New test: errors without exitCode still throw
- [ ] All existing E2B provider tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)