### PR TITLE
fix(core): detect runner crashes on non-streaming providers

### DIFF
--- a/packages/core/src/__tests__/sandbox.test.ts
+++ b/packages/core/src/__tests__/sandbox.test.ts
@@ -726,7 +726,9 @@ describe("runAgentInSandbox", () => {
 			events.push(event as { type: string; content?: string; code?: string });
 		}
 
-		const errorEvent = events.find((e) => e.type === "error" && e.code === "RUNNER_ERROR");
+		const errorEvent = events.find(
+			(e) => e.type === "error" && e.code === "RUNNER_ERROR",
+		);
 		expect(errorEvent).toBeDefined();
 		expect(errorEvent?.content).toContain("139");
 	});
@@ -753,14 +755,13 @@ describe("runAgentOnInstance", () => {
 		);
 
 		const events: Array<{ type: string; content?: string; code?: string }> = [];
-		for await (const event of runAgentOnInstance(
-			instance,
-			makeRequest(),
-		)) {
+		for await (const event of runAgentOnInstance(instance, makeRequest())) {
 			events.push(event as { type: string; content?: string; code?: string });
 		}
 
-		const errorEvent = events.find((e) => e.type === "error" && e.code === "RUNNER_ERROR");
+		const errorEvent = events.find(
+			(e) => e.type === "error" && e.code === "RUNNER_ERROR",
+		);
 		expect(errorEvent).toBeDefined();
 		expect(errorEvent?.content).toContain("139");
 	});
@@ -771,10 +772,7 @@ describe("runAgentOnInstance", () => {
 		]);
 
 		const events: Array<{ type: string; code?: string }> = [];
-		for await (const event of runAgentOnInstance(
-			instance,
-			makeRequest(),
-		)) {
+		for await (const event of runAgentOnInstance(instance, makeRequest())) {
 			events.push(event as { type: string; code?: string });
 		}
 

--- a/packages/core/src/__tests__/sandbox.test.ts
+++ b/packages/core/src/__tests__/sandbox.test.ts
@@ -46,7 +46,11 @@ import {
 	extractGeneratedFiles,
 	uploadFiles,
 } from "../files.js";
-import { runAgentInSandbox, SandboxError } from "../sandbox.js";
+import {
+	runAgentInSandbox,
+	runAgentOnInstance,
+	SandboxError,
+} from "../sandbox.js";
 import type { SandboxInstance, SandboxProvider } from "../sandbox-provider.js";
 import { registerSandboxProvider, resetRegistry } from "../sandbox-registry.js";
 import type { QueryRequest } from "../schemas.js";
@@ -691,6 +695,91 @@ describe("runAgentInSandbox", () => {
 	it("SandboxError is instanceof Error", () => {
 		const err = new SandboxError("failed", "create");
 		expect(err).toBeInstanceOf(Error);
+	});
+
+	// -------------------------------------------------------------------------
+	// Non-zero exit code detection (non-streaming providers)
+	// -------------------------------------------------------------------------
+
+	it("yields RUNNER_ERROR when runner exits with non-zero code (non-streaming provider)", async () => {
+		const instance = makeFakeInstance([]);
+		// Simulate a non-streaming provider: commands.run resolves successfully
+		// but with a non-zero exit code (e.g. Docker with reject: false)
+		instance.commands.run.mockImplementation(
+			async (
+				_cmd: string,
+				opts?: {
+					onStdout?: (data: string) => void;
+					onStderr?: (data: string) => void;
+				},
+			) => {
+				opts?.onStderr?.("Segmentation fault\n");
+				return { stdout: "", stderr: "Segmentation fault", exitCode: 139 };
+			},
+		);
+		registerFakeProvider(instance);
+
+		const events: Array<{ type: string; content?: string; code?: string }> = [];
+		for await (const event of runAgentInSandbox({
+			request: makeRequest(),
+		})) {
+			events.push(event as { type: string; content?: string; code?: string });
+		}
+
+		const errorEvent = events.find((e) => e.type === "error" && e.code === "RUNNER_ERROR");
+		expect(errorEvent).toBeDefined();
+		expect(errorEvent?.content).toContain("139");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// runAgentOnInstance — non-zero exit code detection
+// ---------------------------------------------------------------------------
+
+describe("runAgentOnInstance", () => {
+	it("yields RUNNER_ERROR when runner exits with non-zero code", async () => {
+		const instance = makeFakeInstance([]);
+		instance.commands.run.mockImplementation(
+			async (
+				_cmd: string,
+				opts?: {
+					onStdout?: (data: string) => void;
+					onStderr?: (data: string) => void;
+				},
+			) => {
+				opts?.onStderr?.("Segmentation fault\n");
+				return { stdout: "", stderr: "Segmentation fault", exitCode: 139 };
+			},
+		);
+
+		const events: Array<{ type: string; content?: string; code?: string }> = [];
+		for await (const event of runAgentOnInstance(
+			instance,
+			makeRequest(),
+		)) {
+			events.push(event as { type: string; content?: string; code?: string });
+		}
+
+		const errorEvent = events.find((e) => e.type === "error" && e.code === "RUNNER_ERROR");
+		expect(errorEvent).toBeDefined();
+		expect(errorEvent?.content).toContain("139");
+	});
+
+	it("does not yield error when runner exits with code 0", async () => {
+		const instance = makeFakeInstance([
+			JSON.stringify({ type: "result", content: "done" }),
+		]);
+
+		const events: Array<{ type: string; code?: string }> = [];
+		for await (const event of runAgentOnInstance(
+			instance,
+			makeRequest(),
+		)) {
+			events.push(event as { type: string; code?: string });
+		}
+
+		const errorEvent = events.find((e) => e.code === "RUNNER_ERROR");
+		expect(errorEvent).toBeUndefined();
 	});
 });
 

--- a/packages/core/src/sandbox.ts
+++ b/packages/core/src/sandbox.ts
@@ -415,10 +415,17 @@ export async function* runAgentInSandbox(
 					}
 				},
 			})
-			.then(() => {
+			.then((result) => {
 				// Flush any remaining buffered content
 				if (stdoutBuffer.trim()) stream.push(stdoutBuffer);
-				stream.end();
+				if (result.exitCode !== 0) {
+					const detail = _stderrBuffer.trim()
+						? `Runner exited with code ${result.exitCode}\nstderr: ${_stderrBuffer.trim()}`
+						: `Runner exited with code ${result.exitCode}`;
+					stream.destroy(new Error(detail));
+				} else {
+					stream.end();
+				}
 			})
 			.catch((err: unknown) => {
 				stream.destroy(err instanceof Error ? err : new Error(String(err)));
@@ -629,9 +636,16 @@ export async function* runAgentOnInstance(
 				}
 			},
 		})
-		.then(() => {
+		.then((result) => {
 			if (stdoutBuffer.trim()) stream.push(stdoutBuffer);
-			stream.end();
+			if (result.exitCode !== 0) {
+				const detail = stderrBuffer.trim()
+					? `Runner exited with code ${result.exitCode}\nstderr: ${stderrBuffer.trim()}`
+					: `Runner exited with code ${result.exitCode}`;
+				stream.destroy(new Error(detail));
+			} else {
+				stream.end();
+			}
 		})
 		.catch((err: unknown) => {
 			stream.destroy(err instanceof Error ? err : new Error(String(err)));


### PR DESCRIPTION
## Summary
- Check exit code in command `.then()` handler for both `runAgentInSandbox` and `runAgentOnInstance`
- Non-zero exit codes now destroy the stream with an error, producing a `RUNNER_ERROR` event
- Fixes silent crash reporting on Docker, Vercel, and Cloudflare providers

Closes #66

## Test plan
- [x] New test: non-zero exit code produces RUNNER_ERROR event (`runAgentInSandbox`)
- [x] New test: non-zero exit code produces RUNNER_ERROR event (`runAgentOnInstance`)
- [x] New test: exit code 0 does not produce error (`runAgentOnInstance`)
- [x] All existing sandbox tests pass (884/885 — 1 pre-existing SIGTERM failure unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)