### PR TITLE
fix(api): send SSE error event on mid-stream failures

### DIFF
--- a/apps/api/src/__tests__/routes/sessions.test.ts
+++ b/apps/api/src/__tests__/routes/sessions.test.ts
@@ -226,6 +226,40 @@ describe("POST /sessions/:id/messages", () => {
 		expect(text).toContain("event: assistant");
 	});
 
+	test("emits SSE error event when the event generator throws mid-stream", async () => {
+		const sessionManager = createTestSessionManager();
+		const app = createApp({ sessionManager });
+
+		// Create a session first
+		const createRes = await postSession(app, { prompt: "init" });
+		const createText = await createRes.text();
+		const match = createText.match(/"sessionId":"([^"]+)"/);
+		const sessionId = match?.[1] as string;
+		expect(sessionId).toBeDefined();
+
+		// Mock sendMessage to return an async generator that throws mid-stream
+		vi.spyOn(sessionManager, "sendMessage").mockImplementation(
+			async function () {
+				return (async function* () {
+					yield {
+						type: "assistant",
+						content: "Partial",
+					} satisfies SandcasterEvent;
+					throw new Error("command execution failed");
+				})();
+			},
+		);
+
+		const res = await postMessage(app, sessionId, { prompt: "trigger error" });
+		expect(res.status).toBe(200);
+
+		const text = await res.text();
+		expect(text).toContain("event: assistant");
+		expect(text).toContain("event: error");
+		expect(text).toContain("STREAM_ERROR");
+		expect(text).toContain("command execution failed");
+	});
+
 	test("detects /status command and returns session_command_result event", async () => {
 		const sessionManager = createTestSessionManager();
 		const app = createApp({ sessionManager });

--- a/apps/api/src/routes/sessions.ts
+++ b/apps/api/src/routes/sessions.ts
@@ -17,10 +17,22 @@ async function _drainEventsToSSE(
 	events: AsyncIterable<SandcasterEvent>,
 ): Promise<void> {
 	c.header("Content-Encoding", "Identity");
-	for await (const event of events) {
+	try {
+		for await (const event of events) {
+			await stream.writeSSE({
+				event: event.type,
+				data: JSON.stringify(event),
+			});
+		}
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
 		await stream.writeSSE({
-			event: event.type,
-			data: JSON.stringify(event),
+			event: "error",
+			data: JSON.stringify({
+				type: "error",
+				content: message,
+				code: "STREAM_ERROR",
+			}),
 		});
 	}
 }


### PR DESCRIPTION
## Summary
- Wrap `_drainEventsToSSE` for-await loop in try-catch
- Mid-stream errors now emit an `error` SSE event with code `STREAM_ERROR` before the stream closes
- Clients can now detect and handle stream failures instead of seeing silent disconnects

Closes #67

## Test plan
- [ ] New test: mid-stream generator error produces SSE error event
- [ ] All existing session route tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)