### PR TITLE
fix(core): propagate abort signal in runAgentOnInstance and delete promptly

### DIFF
--- a/packages/core/src/__tests__/sandbox.test.ts
+++ b/packages/core/src/__tests__/sandbox.test.ts
@@ -46,7 +46,11 @@ import {
 	extractGeneratedFiles,
 	uploadFiles,
 } from "../files.js";
-import { runAgentInSandbox, SandboxError } from "../sandbox.js";
+import {
+	runAgentInSandbox,
+	runAgentOnInstance,
+	SandboxError,
+} from "../sandbox.js";
 import type { SandboxInstance, SandboxProvider } from "../sandbox-provider.js";
 import { registerSandboxProvider, resetRegistry } from "../sandbox-registry.js";
 import type { QueryRequest } from "../schemas.js";
@@ -1095,7 +1099,7 @@ describe("runAgentInSandbox — composite orchestration", () => {
 		expect(toolResult?.sandbox).toBeUndefined();
 	});
 
-	it("does NOT overwrite an existing sandbox field on tool_use events", async () => {
+	it("does NOT overwrite an existing sandbox field on tool_use events (composite)", async () => {
 		// If the event already carries a sandbox label, we should keep it.
 		// (The spec says tag when composite active — if already set we pass through.)
 		const toolUseEvent = {
@@ -1262,5 +1266,103 @@ describe("runAgentInSandbox — composite orchestration", () => {
 		const responsePayload = JSON.parse(tmpWriteCall![1]);
 		expect(responsePayload.ok).toBe(true);
 		expect(responsePayload.workDir).toBe(secondaryWorkDir);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// runAgentOnInstance — abort signal handling
+// ---------------------------------------------------------------------------
+
+describe("runAgentOnInstance — abort signal", () => {
+	beforeEach(() => {
+		resetRegistry();
+		process.env.E2B_API_KEY = "test-e2b-key";
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("yields abort error and completes when abort signal fires during stream", async () => {
+		const ac = new AbortController();
+
+		// Simulate a long-running command that never finishes on its own
+		const instance = makeFakeInstance([]);
+		instance.commands.run.mockImplementation(
+			async (
+				_cmd: string,
+				opts?: {
+					onStdout?: (data: string) => void;
+					onStderr?: (data: string) => void;
+				},
+			) => {
+				// Emit one event, then wait indefinitely
+				opts?.onStdout?.(
+					`${JSON.stringify({ type: "assistant", content: "Working..." })}\n`,
+				);
+				// Wait until aborted or long timeout
+				await new Promise<void>((resolve) => {
+					const timer = setTimeout(resolve, 30_000);
+					ac.signal.addEventListener("abort", () => {
+						clearTimeout(timer);
+						resolve();
+					});
+				});
+				return { stdout: "", stderr: "", exitCode: 0 };
+			},
+		);
+
+		const events: Array<{ type: string; content?: string; code?: string }> = [];
+		const genPromise = (async () => {
+			for await (const event of runAgentOnInstance(
+				instance,
+				{ prompt: "test" },
+				undefined,
+				ac.signal,
+			)) {
+				events.push(event);
+			}
+		})();
+
+		// Let the generator start and emit the first event
+		await new Promise((r) => setTimeout(r, 50));
+
+		// Abort
+		ac.abort();
+
+		// The generator should complete promptly
+		await genPromise;
+
+		// Should have the assistant event and an abort error
+		const abortEvent = events.find(
+			(e) => e.type === "error" && e.code === "ABORTED",
+		);
+		expect(abortEvent).toBeDefined();
+	});
+
+	it("returns immediately with abort error when signal is already aborted", async () => {
+		const ac = new AbortController();
+		ac.abort(); // Pre-abort
+
+		const instance = makeFakeInstance([
+			JSON.stringify({ type: "assistant", content: "Should not see this" }),
+		]);
+
+		const events: Array<{ type: string; code?: string }> = [];
+		for await (const event of runAgentOnInstance(
+			instance,
+			{ prompt: "test" },
+			undefined,
+			ac.signal,
+		)) {
+			events.push(event);
+		}
+
+		// Should yield only the abort error, not the assistant event
+		expect(events).toHaveLength(1);
+		expect(events[0]).toMatchObject({ type: "error", code: "ABORTED" });
+
+		// The command should not have been run
+		expect(instance.commands.run).not.toHaveBeenCalled();
 	});
 });

--- a/packages/core/src/__tests__/session/session-manager.test.ts
+++ b/packages/core/src/__tests__/session/session-manager.test.ts
@@ -583,7 +583,9 @@ describe("SessionManager", () => {
 
 		// Spy on mutex.acquire to track call order
 		const mutex = (
-			manager as unknown as { mutexes: Map<string, { acquire: () => Promise<void> }> }
+			manager as unknown as {
+				mutexes: Map<string, { acquire: () => Promise<void> }>;
+			}
 		).mutexes.get(sessionId)!;
 		const origAcquire = mutex.acquire.bind(mutex);
 		mutex.acquire = vi.fn().mockImplementation(async () => {

--- a/packages/core/src/__tests__/session/session-manager.test.ts
+++ b/packages/core/src/__tests__/session/session-manager.test.ts
@@ -484,6 +484,122 @@ describe("SessionManager", () => {
 	});
 
 	// -------------------------------------------------------------------------
+	// Test 9b: deleteSession completes promptly during an active run
+	// -------------------------------------------------------------------------
+
+	it("deleteSession completes promptly even when agent holds the mutex", async () => {
+		const sandbox = createFakeSandbox();
+		const store = createFakeStore();
+
+		let resolveAgent!: () => void;
+		const slowAgent = async function* (
+			_instance: SandboxInstance,
+			_request: unknown,
+			_config: unknown,
+			signal?: AbortSignal,
+		): AsyncGenerator<SandcasterEvent> {
+			// Wait for abort or a long time — simulating an agent that takes 30+ min
+			await new Promise<void>((resolve) => {
+				resolveAgent = resolve;
+				if (signal) {
+					signal.addEventListener("abort", () => resolve(), { once: true });
+				}
+				// Fallback after 30s (should not be reached)
+				setTimeout(resolve, 30_000);
+			});
+			yield {
+				type: "result",
+				content: "Done",
+				costUsd: 0,
+				numTurns: 0,
+				durationSecs: 0,
+			} satisfies SandcasterEvent;
+		};
+
+		const manager = new SessionManager({
+			store,
+			sandboxFactory: vi.fn().mockResolvedValue(sandbox),
+			runAgent: createFakeRunAgent(),
+		});
+
+		const { sessionId, events: createEvents } = await manager.createSession(
+			makeSessionCreateRequest({ prompt: undefined }),
+		);
+		await collectEvents(createEvents);
+
+		// Switch to slow agent
+		(manager as unknown as { opts: { runAgent: unknown } }).opts.runAgent =
+			slowAgent;
+
+		// Start a long-running message
+		const msgGenPromise = manager.sendMessage(sessionId, {
+			prompt: "slow task",
+		});
+
+		// Give it a tick to start
+		await new Promise((r) => setTimeout(r, 0));
+
+		// deleteSession should complete within a reasonable time (not hang for 30s)
+		const start = Date.now();
+		await manager.deleteSession(sessionId);
+		const elapsed = Date.now() - start;
+
+		// Should complete in under 2 seconds (not 30+)
+		expect(elapsed).toBeLessThan(2000);
+
+		// Session should be ended
+		expect(store.get(sessionId)?.status).toBe("ended");
+
+		// Clean up — consume the generator
+		const gen = await msgGenPromise;
+		await collectEvents(gen);
+	});
+
+	// -------------------------------------------------------------------------
+	// Test 9c: deleteSession kills instance before mutex acquisition
+	// -------------------------------------------------------------------------
+
+	it("deleteSession kills sandbox instance before acquiring mutex", async () => {
+		const sandbox = createFakeSandbox();
+		const store = createFakeStore();
+
+		const callOrder: string[] = [];
+
+		// Track kill calls
+		sandbox.kill = vi.fn().mockImplementation(async () => {
+			callOrder.push("kill");
+		});
+
+		const manager = new SessionManager({
+			store,
+			sandboxFactory: vi.fn().mockResolvedValue(sandbox),
+			runAgent: createFakeRunAgent(),
+		});
+
+		const { sessionId, events: createEvents } = await manager.createSession(
+			makeSessionCreateRequest({ prompt: undefined }),
+		);
+		await collectEvents(createEvents);
+
+		// Spy on mutex.acquire to track call order
+		const mutex = (
+			manager as unknown as { mutexes: Map<string, { acquire: () => Promise<void> }> }
+		).mutexes.get(sessionId)!;
+		const origAcquire = mutex.acquire.bind(mutex);
+		mutex.acquire = vi.fn().mockImplementation(async () => {
+			callOrder.push("mutex.acquire");
+			return origAcquire();
+		});
+
+		await manager.deleteSession(sessionId);
+
+		// kill should be called BEFORE mutex.acquire
+		expect(callOrder.indexOf("kill")).toBeLessThan(
+			callOrder.indexOf("mutex.acquire"),
+		);
+	});
+
+	// -------------------------------------------------------------------------
 	// Test 10: idle timeout expires session
 	// -------------------------------------------------------------------------
 

--- a/packages/core/src/sandbox.ts
+++ b/packages/core/src/sandbox.ts
@@ -574,6 +574,16 @@ export async function* runAgentOnInstance(
 	const timeoutMs = timeoutSecs * 1000;
 	const envs = buildEnvs(request);
 
+	// Check if already aborted before starting
+	if (_signal?.aborted) {
+		yield {
+			type: "error",
+			content: "Aborted",
+			code: "ABORTED",
+		} satisfies SandcasterEvent;
+		return;
+	}
+
 	const runnerDir = `${instance.workDir}/.sandcaster`;
 	const runnerPath = `${runnerDir}/runner.mjs`;
 	const configPath = `${runnerDir}/agent_config.json`;
@@ -617,6 +627,12 @@ export async function* runAgentOnInstance(
 		}
 	};
 
+	// Set up abort listener to destroy the stream
+	const onAbort = () => {
+		stream.destroy(new Error("Aborted"));
+	};
+	_signal?.addEventListener("abort", onAbort, { once: true });
+
 	const runPromise = instance.commands
 		.run(`node ${runnerPath} ${configPath}`, {
 			timeoutMs: timeoutMs * 6,
@@ -653,16 +669,26 @@ export async function* runAgentOnInstance(
 			}
 		}
 	} catch (streamErr) {
-		const errMsg =
-			streamErr instanceof Error ? streamErr.message : String(streamErr);
-		const detail = stderrBuffer.trim()
-			? `${errMsg}\nstderr: ${stderrBuffer.trim()}`
-			: errMsg;
-		yield {
-			type: "error",
-			content: redactApiKeys(`Runner error: ${detail}`, envs),
-			code: "RUNNER_ERROR",
-		} satisfies SandcasterEvent;
+		if (_signal?.aborted) {
+			yield {
+				type: "error",
+				content: "Aborted",
+				code: "ABORTED",
+			} satisfies SandcasterEvent;
+		} else {
+			const errMsg =
+				streamErr instanceof Error ? streamErr.message : String(streamErr);
+			const detail = stderrBuffer.trim()
+				? `${errMsg}\nstderr: ${stderrBuffer.trim()}`
+				: errMsg;
+			yield {
+				type: "error",
+				content: redactApiKeys(`Runner error: ${detail}`, envs),
+				code: "RUNNER_ERROR",
+			} satisfies SandcasterEvent;
+		}
+	} finally {
+		_signal?.removeEventListener("abort", onAbort);
 	}
 
 	await runPromise.catch(() => {});

--- a/packages/core/src/session/session-manager.ts
+++ b/packages/core/src/session/session-manager.ts
@@ -379,7 +379,19 @@ export class SessionManager {
 			activeSession.abortController.abort();
 		}
 
-		// Wait for mutex
+		// Kill the sandbox instance BEFORE acquiring the mutex.
+		// This terminates the running command, which unblocks the agent generator,
+		// which releases the mutex. Without this, deleteSession hangs until the
+		// agent naturally completes (potentially 30+ minutes).
+		if (activeSession.instance) {
+			try {
+				await activeSession.instance.kill();
+			} catch {
+				// best-effort
+			}
+		}
+
+		// Now acquire mutex (should be released quickly since the command was killed)
 		const mutex = this._getMutex(sessionId);
 		await mutex.acquire();
 
@@ -388,14 +400,6 @@ export class SessionManager {
 			if (!this.activeSessions.has(sessionId)) return;
 
 			this._clearIdleTimer(sessionId);
-
-			if (activeSession.instance) {
-				try {
-					await activeSession.instance.kill();
-				} catch {
-					// best-effort
-				}
-			}
 
 			activeSession.session.status = "ended";
 			this.opts.store.update(sessionId, { status: "ended" });


### PR DESCRIPTION
## Summary
- Propagate `AbortSignal` in `runAgentOnInstance` to destroy the stream on abort
- Kill sandbox instance in `deleteSession` BEFORE acquiring the mutex, so the running command terminates and the mutex is released promptly
- Session deletion no longer hangs for the duration of the agent run

Closes #63
Closes #64

## Test plan
- [x] Test: abort signal causes generator to yield error and complete
- [x] Test: pre-aborted signal returns immediately
- [x] Test: deleteSession completes promptly during active run
- [x] Test: deleteSession kills instance before mutex acquisition
- [x] Existing abort test (test 9) still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)