### PR TITLE
fix(pr-companion): read agent output from assistant events

### DIFF
--- a/examples/16-github-pr-companion/gateway/src/__tests__/integration.test.ts
+++ b/examples/16-github-pr-companion/gateway/src/__tests__/integration.test.ts
@@ -127,11 +127,17 @@ const CANNED_AGENT_OUTPUT: AgentOutput = {
 	summary: "Fixed 1 comment",
 };
 
-/** Mock runAgent that yields a single result event */
+/** Mock runAgent that yields the agent's final assistant text */
 async function* mockRunAgent(_prompt: string): AsyncGenerator<SandcasterEvent> {
 	yield {
-		type: "result",
+		type: "assistant",
+		subtype: "complete",
 		content: JSON.stringify(CANNED_AGENT_OUTPUT),
+	};
+	yield {
+		type: "result",
+		subtype: "success",
+		content: "Agent completed",
 	};
 }
 

--- a/examples/16-github-pr-companion/gateway/src/index.ts
+++ b/examples/16-github-pr-companion/gateway/src/index.ts
@@ -129,16 +129,19 @@ async function processReview(
 			const batch = allComments.slice(i, i + MAX_COMMENTS_PER_BATCH);
 			const prompt = formatPrompt(batch);
 
-			let resultContent = "";
+			// Agent output arrives via `assistant` events (`subtype: "complete"`
+			// carries the full text of each assistant turn). `result.content` is
+			// always the static string "Agent completed" and is for metadata only.
+			let assistantText = "";
 			for await (const ev of deps.runAgent(prompt)) {
-				if (ev.type === "result") {
-					resultContent = ev.content;
+				if (ev.type === "assistant" && ev.subtype === "complete") {
+					assistantText = ev.content;
 				}
 			}
 
-			if (!resultContent) continue;
+			if (!assistantText) continue;
 
-			const agentOutput = JSON.parse(resultContent);
+			const agentOutput = JSON.parse(assistantText);
 			const token = await getToken();
 
 			const result = await applier.applyAndPush({


### PR DESCRIPTION
## Summary
- The gateway was reading `result.content` as agent JSON output, but that field is hardcoded to the static string `"Agent completed"` by the event translator. Every webhook delivery threw `SyntaxError` on `JSON.parse`, silently failing all PR review processing.
- Switched to reading from `assistant` events (`subtype: "complete"`), which is the actual contract for assistant text output.
- Fixed the integration test mock, which yielded a malformed `result` event (no `subtype`) carrying JSON — this masked the bug.

Fixes #86

## Test plan
- [x] `bunx vitest run` — all 87 gateway tests pass
- [x] `bunx tsc --noEmit` — no type errors