### PR TITLE
fix(branching): preserve branch_start/branch_complete invariant on stagger abort

### DIFF
--- a/packages/core/src/branching/__tests__/branch-orchestrator.test.ts
+++ b/packages/core/src/branching/__tests__/branch-orchestrator.test.ts
@@ -540,6 +540,54 @@ describe("abort signal propagation", () => {
 		// and that the abort was respected
 		expect(controller.signal.aborted).toBe(true);
 	});
+
+	it("does not emit branch_start without a matching branch_complete when abort fires during stagger", async () => {
+		const controller = new AbortController();
+
+		let callCount = 0;
+		const runAgent: BranchRunOptions["runAgent"] = async function* () {
+			callCount++;
+			if (callCount === 1) {
+				yield ASSISTANT_EVENT;
+				yield {
+					type: "branch_request",
+					alternatives: ["A", "B", "C"],
+				} satisfies SandcasterEvent;
+			} else {
+				yield {
+					type: "result",
+					content: "done",
+					costUsd: 0.01,
+					numTurns: 1,
+				};
+			}
+		};
+
+		const gen = runBranchedAgent({
+			request: { prompt: "hello" },
+			runAgent,
+			// Stagger long enough that abort lands during the wait between branches
+			config: { branching: { staggerDelayMs: 100 } },
+			signal: controller.signal,
+		});
+
+		// Abort while the orchestrator is waiting in stagger between branches
+		setTimeout(() => controller.abort(), 50);
+
+		const events: SandcasterEvent[] = [];
+		try {
+			for await (const event of gen) {
+				events.push(event);
+			}
+		} catch {
+			// abort may throw
+		}
+
+		const starts = events.filter((e) => e.type === "branch_start");
+		const completes = events.filter((e) => e.type === "branch_complete");
+		// Lifecycle invariant: every branch_start has a matching branch_complete
+		expect(starts.length).toBe(completes.length);
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/branching/branch-orchestrator.ts
+++ b/packages/core/src/branching/branch-orchestrator.ts
@@ -429,6 +429,14 @@ async function* runBranchingPath(
 		const branchId = branchIds[i];
 		const alternative = alternatives[i];
 
+		// Stagger: delay before starting the next branch
+		if (i > 0 && staggerDelayMs > 0) {
+			await new Promise((r) => setTimeout(r, staggerDelayMs));
+			// Check abort after stagger wait — must run before branch_start
+			// is yielded so we don't emit a start without a matching complete.
+			if (branchAbortController.signal.aborted) break;
+		}
+
 		yield {
 			type: "branch_start",
 			branchId,
@@ -436,13 +444,6 @@ async function* runBranchingPath(
 			totalBranches,
 			prompt: alternative,
 		};
-
-		// Stagger: delay before starting the next branch
-		if (i > 0 && staggerDelayMs > 0) {
-			await new Promise((r) => setTimeout(r, staggerDelayMs));
-			// Check abort after stagger wait
-			if (branchAbortController.signal.aborted) break;
-		}
 
 		const branchPromise = runSingleBranch(
 			branchId,


### PR DESCRIPTION
## Summary
- Orchestrator yielded `branch_start` BEFORE the stagger delay + post-delay abort check. When abort fired during stagger, the loop broke after the start was emitted but before the branch promise was pushed, breaking the lifecycle invariant `branch_start.length === branch_complete.length`.
- Moved stagger delay + abort check above the `branch_start` emission so any yielded start is guaranteed a corresponding settled promise.
- Added regression test that aborts during stagger and asserts the lifecycle invariant.

Fixes #93

## Test plan
- [x] New regression test fails on main, passes after fix
- [x] `bunx vitest run packages/core/src/branching` — all 40 tests pass