### PR TITLE
fix(session): validate role order before trimming tool call pair

### DIFF
--- a/packages/core/src/__tests__/session/conversation.test.ts
+++ b/packages/core/src/__tests__/session/conversation.test.ts
@@ -63,6 +63,28 @@ describe("addTurn", () => {
 		expect(history[2].content).toBe("new response");
 	});
 
+	it("does not orphan a tool_result when an unpaired tool_use precedes a complete pair", () => {
+		// Scenario: abort interrupted a previous run between tool_use(A) and
+		// tool_result(A), leaving an orphaned assistant tool_use. A later run
+		// completed a full tool_use(B) → tool_result(B) pair. Trimming must
+		// drop only the orphan, not consume tool_use(B) as if it were
+		// tool_result(A).
+		const history: ConversationTurn[] = [
+			{ role: "assistant", content: "tool_use(A)", isToolCall: true },
+			{ role: "assistant", content: "tool_use(B)", isToolCall: true },
+			{ role: "user", content: "tool_result(B)", isToolCall: true },
+			{ role: "assistant", content: "response" },
+		];
+
+		addTurn(history, { role: "user", content: "next" }, 4);
+
+		expect(history).toHaveLength(4);
+		expect(history[0].content).toBe("tool_use(B)");
+		expect(history[1].content).toBe("tool_result(B)");
+		expect(history[2].content).toBe("response");
+		expect(history[3].content).toBe("next");
+	});
+
 	it("does not split a tool call pair when trimming", () => {
 		const history: ConversationTurn[] = [
 			{ role: "user", content: "regular" },

--- a/packages/core/src/session/conversation.ts
+++ b/packages/core/src/session/conversation.ts
@@ -15,8 +15,19 @@ export function addTurn(
 	history.push(turn);
 
 	while (history.length > maxTurns) {
-		if (history[0]?.isToolCall && history[1]?.isToolCall) {
-			// Remove both turns of the tool call pair
+		const first = history[0];
+		const second = history[1];
+		// A valid tool call pair is `assistant` (tool_use) followed by `user`
+		// (tool_result). Two consecutive isToolCall turns with the wrong roles
+		// (e.g. two orphaned assistant tool_use entries left by an abort) must
+		// not be removed together — that would consume an unrelated entry and
+		// orphan its partner.
+		if (
+			first?.isToolCall &&
+			second?.isToolCall &&
+			first.role === "assistant" &&
+			second.role === "user"
+		) {
 			history.splice(0, 2);
 		} else {
 			history.splice(0, 1);


### PR DESCRIPTION
## Summary
- `addTurn`'s pair-aware trim treated any two leading `isToolCall: true` turns as a `tool_use → tool_result` pair without checking roles. After an abort orphans a `tool_use` (assistant) and a later run appends a complete pair, the first two slots are `tool_use(A)` followed by `tool_use(B)` — both assistant. The loop removed both, orphaning `tool_result(B)`.
- Now only collapse two leading turns when the role order is `assistant → user`; otherwise drop only the single orphan.

Fixes #84

## Test plan
- [x] Added regression test for the orphan-followed-by-pair scenario (fails on main, passes after fix).
- [x] All 15 conversation tests pass.