### PR TITLE
fix(session): atomic capacity reservation in createSession

### DIFF
--- a/packages/core/src/__tests__/session/session-manager.test.ts
+++ b/packages/core/src/__tests__/session/session-manager.test.ts
@@ -791,6 +791,46 @@ describe("SessionManager", () => {
 		).rejects.toMatchObject({ code: "SESSION_CAPACITY_EXCEEDED" });
 	});
 
+	it("createSession capacity check is atomic under concurrent calls", async () => {
+		const store = createFakeStore();
+		// Slow sandbox factory: each call takes 30ms before resolving, so concurrent
+		// callers reach the size check before any of them has registered.
+		const sandboxFactory = vi.fn(async () => {
+			await new Promise((r) => setTimeout(r, 30));
+			return createFakeSandbox();
+		});
+
+		const manager = new SessionManager({
+			store,
+			sandboxFactory,
+			runAgent: createFakeRunAgent(),
+			maxActiveSessions: 2,
+		});
+
+		// Fire 5 concurrent createSession calls against a cap of 2.
+		const results = await Promise.allSettled(
+			Array.from({ length: 5 }, () =>
+				manager
+					.createSession(makeSessionCreateRequest({ prompt: undefined }))
+					.then(async (r) => {
+						await collectEvents(r.events);
+						return r;
+					}),
+			),
+		);
+
+		const fulfilled = results.filter((r) => r.status === "fulfilled");
+		const rejected = results.filter((r) => r.status === "rejected");
+
+		expect(fulfilled).toHaveLength(2);
+		expect(rejected).toHaveLength(3);
+		for (const r of rejected) {
+			expect((r as PromiseRejectedResult).reason).toMatchObject({
+				code: "SESSION_CAPACITY_EXCEEDED",
+			});
+		}
+	});
+
 	// -------------------------------------------------------------------------
 	// Test 16: sendMessage throws SESSION_NOT_FOUND for unknown session
 	// -------------------------------------------------------------------------

--- a/packages/core/src/session/session-manager.ts
+++ b/packages/core/src/session/session-manager.ts
@@ -171,6 +171,10 @@ function eagerBuffer<T>(source: AsyncGenerator<T>): AsyncGenerator<T> {
 export class SessionManager {
 	private readonly activeSessions = new Map<string, ActiveSession>();
 	private readonly mutexes = new Map<string, Mutex>();
+	// In-flight createSession calls that have passed the capacity check but
+	// not yet registered. Reserved synchronously so concurrent callers
+	// observe the pending allocation before any await yields.
+	private reservedSlots = 0;
 
 	constructor(private readonly opts: SessionManagerOptions) {}
 
@@ -200,12 +204,16 @@ export class SessionManager {
 		const maxActive =
 			this.opts.maxActiveSessions ?? DEFAULT_MAX_ACTIVE_SESSIONS;
 
-		if (this.activeSessions.size >= maxActive) {
+		// Atomic capacity reservation: the check + reserve happens with no
+		// `await` in between, so concurrent callers cannot all observe an
+		// under-capacity snapshot and overshoot the limit.
+		if (this.activeSessions.size + this.reservedSlots >= maxActive) {
 			throw new SessionError(
 				`Session capacity limit reached (max ${maxActive})`,
 				"SESSION_CAPACITY_EXCEEDED",
 			);
 		}
+		this.reservedSlots++;
 
 		const sessionId = generateSessionId();
 		const now = nowIso();
@@ -238,6 +246,7 @@ export class SessionManager {
 				apiKey: request.apiKeys?.e2b,
 			});
 		} catch (err) {
+			this.reservedSlots--;
 			this.opts.store.update(sessionId, { status: "failed" });
 			throw err;
 		}
@@ -281,6 +290,9 @@ export class SessionManager {
 
 		this.activeSessions.set(sessionId, activeSession);
 		this.mutexes.set(sessionId, new Mutex());
+		// Reservation now backed by a real entry in activeSessions; release the
+		// in-flight counter so subsequent calls see the up-to-date occupancy.
+		this.reservedSlots--;
 
 		// Start idle timer
 		this._startIdleTimer(sessionId, idleTimeoutMs);


### PR DESCRIPTION
## Summary
- `createSession` checked `activeSessions.size >= maxActiveSessions` and then awaited the sandbox factory before registering. Concurrent callers all observed the same below-limit snapshot, all passed the check, and all registered — overshooting the cap.
- Introduce a synchronous `reservedSlots` counter incremented in the same tick as the check. The check now considers `activeSessions.size + reservedSlots`, so any in-flight create counts toward the cap before its factory resolves. Released on registration or factory failure.

Fixes #87

## Test plan
- [x] Added regression: 5 concurrent createSession calls vs cap=2 — exactly 2 fulfill, 3 reject with `SESSION_CAPACITY_EXCEEDED` (fails on main).
- [x] All 27 session-manager tests pass.