### PR TITLE
fix(tools): throw on bash command failure so framework emits tool error

### DIFF
--- a/packages/core/src/__tests__/runner/sandbox-tools.test.ts
+++ b/packages/core/src/__tests__/runner/sandbox-tools.test.ts
@@ -88,17 +88,16 @@ describe("createSandboxTools", () => {
 			expect(result.details).toMatchObject({ exitCode: 0 });
 		});
 
-		it("returns structured error with exit code and stderr on non-zero exit", async () => {
+		it("throws on non-zero exit so the framework reports a tool error", async () => {
 			const tools = createSandboxTools({ cwd: tmpDir });
 			const bash = tools.find((t) => t.name === "bash")!;
 
-			const result = await bash.execute("call-2", {
-				command: "echo err >&2; exit 42",
-			});
-
-			expect(result.details.exitCode).toBe(42);
-			expect((result as any).isError).toBe(true);
-			expect((result.content[0] as any).text).toContain("err");
+			// The framework only marks a tool call as `isError: true` when the
+			// tool throws — returning `{ isError: true }` is ignored by
+			// providers (notably Gemini). The bash tool must therefore raise.
+			await expect(
+				bash.execute("call-2", { command: "echo err >&2; exit 42" }),
+			).rejects.toThrow(/err|exit code 42/);
 		});
 
 		it("uses custom cwd when provided", async () => {
@@ -113,28 +112,24 @@ describe("createSandboxTools", () => {
 			});
 		});
 
-		it("returns error result when cwd does not exist", async () => {
+		it("throws when cwd does not exist", async () => {
 			const tools = createSandboxTools({
 				cwd: join(tmpDir, "nonexistent-cwd"),
 			});
 			const bash = tools.find((t) => t.name === "bash")!;
 
-			const result = await bash.execute("call-4", { command: "echo ok" });
-
-			expect((result as any).isError).toBe(true);
-			expect((result.content[0] as any).text).toContain("ENOENT");
+			await expect(
+				bash.execute("call-4", { command: "echo ok" }),
+			).rejects.toThrow(/ENOENT/);
 		});
 
-		it("returns error result when command times out", async () => {
+		it("throws when command times out", async () => {
 			const tools = createSandboxTools({ cwd: tmpDir });
 			const bash = tools.find((t) => t.name === "bash")!;
 
-			const result = await bash.execute("call-5", {
-				command: "sleep 10",
-				timeout: 1,
-			});
-
-			expect((result as any).isError).toBe(true);
+			await expect(
+				bash.execute("call-5", { command: "sleep 10", timeout: 1 }),
+			).rejects.toThrow();
 		});
 	});
 

--- a/packages/core/src/runner/sandbox-tools.ts
+++ b/packages/core/src/runner/sandbox-tools.ts
@@ -40,17 +40,15 @@ export function createSandboxTools(options?: {
 				const exitCode = (err as { status?: number }).status ?? 1;
 				const stderr = (err as { stderr?: string }).stderr ?? "";
 				const stdout = (err as { stdout?: string }).stdout ?? "";
+				const message = (err as { message?: string }).message ?? "";
 				const output = [stdout, stderr].filter(Boolean).join("\n");
-				return {
-					content: [
-						{
-							type: "text" as const,
-							text: output || String(err),
-						},
-					],
-					details: { exitCode },
-					isError: true,
-				};
+				// Throw so pi-agent-core marks the tool call as `isError: true`
+				// and providers (notably Gemini) emit the error-shaped tool
+				// response. Returning `{ isError: true }` is ignored by the
+				// framework — only thrown errors propagate as tool errors.
+				throw new Error(
+					output || message || `Command exited with code ${exitCode}`,
+				);
 			}
 		},
 	};


### PR DESCRIPTION
## Summary
- `pi-agent-core` only marks a tool call as `isError: true` when the tool's `execute` throws. Returning `{ isError: true, details: { exitCode } }` is dead — the framework ignores `result.isError`, and providers don't serialize `result.details`.
- For Gemini specifically this means `functionResponse.response.output` (success-shaped) is sent instead of `functionResponse.response.error`. The model sees a successful call carrying error text.
- Switched the bash tool to throw on failure. The framework's catch wrapper sets `isError: true`, and providers emit the correct error-shaped response.

## Follow-up
- `packages/core/src/runner/composite-tools.ts` uses the same ineffective `{ isError: true }` pattern in its `errorResult` helper. Left for a separate PR so this one stays scoped to #88.

Fixes #88

## Test plan
- [x] Updated tests to assert `rejects.toThrow()` on non-zero exit, timeout, and missing cwd (fail on main, pass after fix).
- [x] All 22 sandbox-tools tests pass.