### PR TITLE
fix(auth): validate API key against RFC 6750 b64token at startup

### DIFF
--- a/apps/api/src/__tests__/middleware/auth.test.ts
+++ b/apps/api/src/__tests__/middleware/auth.test.ts
@@ -3,7 +3,7 @@ import { createApp } from "../../app.js";
 
 describe("bearer auth middleware", () => {
 	test("rejects request with invalid token when apiKey is set", async () => {
-		const app = createApp({ apiKey: "a]d3f5g6h7j8k9l0m1n2o3p4q5r6s7t8" });
+		const app = createApp({ apiKey: "a-d3f5g6h7j8k9l0m1n2o3p4q5r6s7t8" });
 		const res = await app.request("/runs", {
 			headers: { Authorization: "Bearer wrong-key-xxxxxxxxxxxxxxxxxxxxx" },
 		});
@@ -11,7 +11,7 @@ describe("bearer auth middleware", () => {
 	});
 
 	test("allows request with valid token", async () => {
-		const key = "a]d3f5g6h7j8k9l0m1n2o3p4q5r6s7t8";
+		const key = "a-d3f5g6h7j8k9l0m1n2o3p4q5r6s7t8";
 		const app = createApp({ apiKey: key });
 		const res = await app.request("/runs", {
 			headers: { Authorization: `Bearer ${key}` },
@@ -28,13 +28,13 @@ describe("bearer auth middleware", () => {
 	});
 
 	test("health endpoint is public even when apiKey is set", async () => {
-		const app = createApp({ apiKey: "a]d3f5g6h7j8k9l0m1n2o3p4q5r6s7t8" });
+		const app = createApp({ apiKey: "a-d3f5g6h7j8k9l0m1n2o3p4q5r6s7t8" });
 		const res = await app.request("/health");
 		expect(res.status).toBe(200);
 	});
 
 	test("rejects request with no Authorization header when apiKey is set", async () => {
-		const app = createApp({ apiKey: "a]d3f5g6h7j8k9l0m1n2o3p4q5r6s7t8" });
+		const app = createApp({ apiKey: "a-d3f5g6h7j8k9l0m1n2o3p4q5r6s7t8" });
 		const res = await app.request("/runs");
 		expect(res.status).toBe(401);
 	});
@@ -51,6 +51,15 @@ describe("bearer auth middleware", () => {
 
 	test("accepts apiKey exactly at MIN_KEY_LENGTH", () => {
 		expect(() => createApp({ apiKey: "a".repeat(32) })).not.toThrow();
+	});
+
+	test("throws when apiKey contains RFC 6750-invalid characters", () => {
+		// `]` is outside Hono bearerAuth's b64token regex
+		// (`[A-Za-z0-9._~+/-]+=*`). Without startup format validation, every
+		// request to a deployment configured with such a key fails with 400.
+		expect(() =>
+			createApp({ apiKey: "a]d3f5g6h7j8k9l0m1n2o3p4q5r6s7t8" }),
+		).toThrow(/RFC 6750|invalid character|format/i);
 	});
 });
 

--- a/apps/api/src/__tests__/routes/query.test.ts
+++ b/apps/api/src/__tests__/routes/query.test.ts
@@ -151,7 +151,7 @@ describe("POST /query", () => {
 	test("requires auth when apiKey is set", async () => {
 		const app = createApp({
 			runAgent: fakeRunAgent,
-			apiKey: "a]d3f5g6h7j8k9l0m1n2o3p4q5r6s7t8",
+			apiKey: "a-d3f5g6h7j8k9l0m1n2o3p4q5r6s7t8",
 		});
 		const res = await postQuery(app, { prompt: "hello" });
 

--- a/apps/api/src/__tests__/routes/runs.test.ts
+++ b/apps/api/src/__tests__/routes/runs.test.ts
@@ -47,7 +47,7 @@ describe("GET /runs", () => {
 	});
 
 	test("requires auth when apiKey is set", async () => {
-		const app = createApp({ apiKey: "a]d3f5g6h7j8k9l0m1n2o3p4q5r6s7t8" });
+		const app = createApp({ apiKey: "a-d3f5g6h7j8k9l0m1n2o3p4q5r6s7t8" });
 		const res = await app.request("/runs");
 
 		expect(res.status).toBe(401);

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -1,6 +1,7 @@
 import {
 	MIN_KEY_LENGTH,
 	validateBearerToken,
+	validateKeyFormat,
 	validateKeyLength,
 } from "@sandcaster/core";
 import type { MiddlewareHandler } from "hono";
@@ -12,6 +13,11 @@ export function createAuthMiddleware(apiKey: string): MiddlewareHandler {
 	if (!validateKeyLength(apiKey)) {
 		throw new Error(
 			`SANDCASTER_API_KEY must be at least ${MIN_KEY_LENGTH} characters (got ${apiKey.length})`,
+		);
+	}
+	if (!validateKeyFormat(apiKey)) {
+		throw new Error(
+			'SANDCASTER_API_KEY contains characters outside the RFC 6750 b64token set ([A-Za-z0-9._~+/-]+ "=*"). Hono\'s bearerAuth rejects any other character with 400 before verification runs.',
 		);
 	}
 

--- a/packages/core/src/__tests__/auth.test.ts
+++ b/packages/core/src/__tests__/auth.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
 	MIN_KEY_LENGTH,
 	validateBearerToken,
+	validateKeyFormat,
 	validateKeyLength,
 } from "../auth.js";
 
@@ -67,5 +68,29 @@ describe("validateKeyLength", () => {
 describe("MIN_KEY_LENGTH", () => {
 	it("is 32", () => {
 		expect(MIN_KEY_LENGTH).toBe(32);
+	});
+});
+
+describe("validateKeyFormat", () => {
+	// Hono's bearerAuth applies RFC 6750 §2.1 `b64token` validation
+	// (`[A-Za-z0-9._~+/-]+=*`) before invoking verifyToken. Any configured key
+	// that fails this check produces a permanent 400 on every request.
+	it("accepts RFC 6750 b64token characters", () => {
+		expect(validateKeyFormat("a".repeat(32))).toBe(true);
+		expect(validateKeyFormat("ABC._~+/-abcDEF0123456789abcdef01")).toBe(true);
+		expect(validateKeyFormat(`${"a".repeat(30)}==`)).toBe(true);
+	});
+
+	it("rejects characters outside the RFC 6750 b64token set", () => {
+		// `]`, `#`, `$`, `@`, space — all forbidden by Hono's bearerAuth regex
+		expect(validateKeyFormat("a]d3f5g6h7j8k9l0m1n2o3p4q5r6s7t8")).toBe(false);
+		expect(validateKeyFormat(`a${"#".padEnd(31, "a")}`)).toBe(false);
+		expect(validateKeyFormat(`a${"$".padEnd(31, "a")}`)).toBe(false);
+		expect(validateKeyFormat(`a${"@".padEnd(31, "a")}`)).toBe(false);
+		expect(validateKeyFormat(`a${" ".padEnd(31, "a")}`)).toBe(false);
+	});
+
+	it("rejects empty string", () => {
+		expect(validateKeyFormat("")).toBe(false);
 	});
 });

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -19,3 +19,16 @@ export function validateBearerToken(token: string, keys: string[]): boolean {
 export function validateKeyLength(key: string): boolean {
 	return key.length >= MIN_KEY_LENGTH;
 }
+
+// Hono's `bearerAuth` validates the bearer token against RFC 6750 §2.1
+// `b64token` syntax (`1*( ALPHA / DIGIT / "-" / "." / "_" / "~" / "+" / "/" ) *"="`)
+// before invoking the configured verifyToken. Any configured key that fails
+// this check causes every request to fail with 400 — the verifyToken
+// callback never runs. Validating the configured key against the same regex
+// at startup converts this silent runtime failure into an early, actionable
+// error.
+const RFC_6750_TOKEN_REGEX = /^[A-Za-z0-9._~+/-]+=*$/;
+
+export function validateKeyFormat(key: string): boolean {
+	return RFC_6750_TOKEN_REGEX.test(key);
+}


### PR DESCRIPTION
## Summary
- Hono's `bearerAuth` validates the bearer token against RFC 6750 §2.1 `b64token` syntax (\`[A-Za-z0-9._~+/-]+=*\`) before invoking `verifyToken`. Any configured `SANDCASTER_API_KEY` with characters outside that set (e.g. \`]\`, \`#\`, \`$\`, \`@\`, space) silently starts the app but causes every request to return 400 — the verifier never runs.
- Added \`validateKeyFormat\` to \`@sandcaster/core/auth\` and called it from \`createAuthMiddleware\` so misconfigured keys throw at startup with a pointer to the allowed character set.
- Also fixed existing tests that used \`a]d3f5g6h7j8k9l0m1n2o3p4q5r6s7t8\` — that key never authenticated; tests only asserted \`status !== 401\` so a 400 still passed and masked the bug.

Fixes #85

## Test plan
- [x] New \`validateKeyFormat\` tests cover accept/reject + empty input
- [x] New middleware test asserts startup throws for an RFC-invalid key
- [x] All 25 auth tests pass