### PR TITLE
fix(sandbox): register SIGTERM handler in non-composite mode

### DIFF
--- a/packages/core/src/__tests__/sandbox.test.ts
+++ b/packages/core/src/__tests__/sandbox.test.ts
@@ -1242,9 +1242,7 @@ describe("runAgentInSandbox — composite orchestration", () => {
 			// consume
 		}
 
-		const sigtermCall = onSpy.mock.calls.find(
-			(call) => call[0] === "SIGTERM",
-		);
+		const sigtermCall = onSpy.mock.calls.find((call) => call[0] === "SIGTERM");
 		expect(sigtermCall).toBeDefined();
 
 		const sigtermOff = offSpy.mock.calls.find((call) => call[0] === "SIGTERM");

--- a/packages/core/src/__tests__/sandbox.test.ts
+++ b/packages/core/src/__tests__/sandbox.test.ts
@@ -1225,22 +1225,33 @@ describe("runAgentInSandbox — composite orchestration", () => {
 		onSpy.mockRestore();
 	});
 
-	it("does NOT register a SIGTERM handler when composite is NOT active", async () => {
+	it("registers a SIGTERM handler that kills the instance in non-composite mode", async () => {
+		// Without a SIGTERM handler, Node exits immediately on signal and the
+		// `finally` block that calls `instance.kill()` never runs, leaving the
+		// sandbox alive until E2B's idle timeout (default 5 min). The handler
+		// must be registered for non-composite runs too.
 		const instance = makeFakeInstance([]);
 		registerFakeProvider(instance);
 
 		const onSpy = vi.spyOn(process, "on");
+		const offSpy = vi.spyOn(process, "off");
 
 		for await (const _ of runAgentInSandbox({
-			request: makeRequest(), // no composite
+			request: makeRequest(),
 		})) {
 			// consume
 		}
 
-		const sigtermCall = onSpy.mock.calls.find((call) => call[0] === "SIGTERM");
-		expect(sigtermCall).toBeUndefined();
+		const sigtermCall = onSpy.mock.calls.find(
+			(call) => call[0] === "SIGTERM",
+		);
+		expect(sigtermCall).toBeDefined();
+
+		const sigtermOff = offSpy.mock.calls.find((call) => call[0] === "SIGTERM");
+		expect(sigtermOff).toBeDefined();
 
 		onSpy.mockRestore();
+		offSpy.mockRestore();
 	});
 
 	it("removes the SIGTERM handler after the run completes (no leak)", async () => {

--- a/packages/core/src/sandbox.ts
+++ b/packages/core/src/sandbox.ts
@@ -276,7 +276,6 @@ export async function* runAgentInSandbox(
 	let pool: SandboxPool | undefined;
 	let compositeNonce: string | undefined;
 	let resolvedComposite: ReturnType<typeof resolveCompositeConfig> | undefined;
-	let sigTermHandler: (() => Promise<void>) | undefined;
 
 	if (compositeActive) {
 		resolvedComposite = resolveCompositeConfig(
@@ -326,14 +325,21 @@ export async function* runAgentInSandbox(
 
 		// Stale IPC cleanup
 		await instance.commands.run(`rm -f /tmp/sandcaster-ipc-*.json*`);
-
-		// Register SIGTERM handler for graceful cleanup
-		const poolRef = pool;
-		sigTermHandler = async () => {
-			await poolRef.killAll();
-		};
-		process.once("SIGTERM", sigTermHandler);
 	}
+
+	// Register SIGTERM handler for graceful cleanup. Required for both modes:
+	// without a handler, Node exits immediately on SIGTERM and the `finally`
+	// block at the bottom of this function never runs — leaving the sandbox
+	// alive until the provider's idle timeout (5 min on E2B). Composite mode
+	// kills the whole pool; non-composite kills the single instance.
+	const sigTermHandler: () => Promise<void> = async () => {
+		if (pool !== undefined) {
+			await pool.killAll();
+		} else {
+			await instance.kill();
+		}
+	};
+	process.once("SIGTERM", sigTermHandler);
 
 	// Runner directory — use instance.workDir so providers with restricted
 	// filesystems (e.g. Vercel) can write to a writable location.
@@ -550,9 +556,7 @@ export async function* runAgentInSandbox(
 		// ------------------------------------------------------------------
 
 		// Remove SIGTERM handler to prevent leaks
-		if (sigTermHandler !== undefined) {
-			process.off("SIGTERM", sigTermHandler);
-		}
+		process.off("SIGTERM", sigTermHandler);
 
 		if (pool !== undefined) {
 			await pool.killAll();


### PR DESCRIPTION
## Summary
- SIGTERM handler that calls cleanup sat inside `if (compositeActive)`. Without a handler, Node exits immediately on signal — the `finally` block that calls `instance.kill()` never runs and the sandbox stays alive on the provider until idle timeout (5 min on E2B).
- `apps/api/src/node.ts` is the canonical victim: it calls `runAgentInSandbox` directly with no composite config, so a SIGTERM during a run leaks the sandbox.
- Move handler registration out of the composite branch. The handler checks pool presence at signal time and kills accordingly. The existing `finally` already removes the handler.

Fixes #92

## Test plan
- [x] Flipped the existing "does NOT register a SIGTERM handler when composite is NOT active" test (which asserted the bug) to verify the handler IS now registered in non-composite mode and removed on completion.
- [x] All 48 sandbox tests pass.