### PR TITLE
fix(vercel): preserve partial output and close log stream on timeout

### DIFF
--- a/packages/core/src/__tests__/providers/vercel.test.ts
+++ b/packages/core/src/__tests__/providers/vercel.test.ts
@@ -485,12 +485,17 @@ describe("createVercelProvider", () => {
 	});
 
 	it("enforces per-command timeoutMs and returns exitCode -1 on timeout", async () => {
+		// Real Vercel SDK aborts the underlying HTTP stream when its `signal`
+		// option fires. Mirror that behavior in the mock by rejecting on abort.
 		const runCommand = vi.fn().mockResolvedValue({
 			exitCode: 0,
-			logs: () =>
+			logs: (logsOpts?: { signal?: AbortSignal }) =>
 				(async function* () {
-					// Never yields — simulates a hung command
-					await new Promise(() => {});
+					await new Promise<void>((_, reject) => {
+						logsOpts?.signal?.addEventListener("abort", () =>
+							reject(new Error("aborted")),
+						);
+					});
 				})(),
 		});
 		const fakeSbx = makeVercelSandbox({ runCommand });
@@ -506,6 +511,71 @@ describe("createVercelProvider", () => {
 		});
 		expect(cmdRes.exitCode).toBe(-1);
 		expect(cmdRes.stderr).toContain("timeout");
+	});
+
+	it("preserves partial stdout/stderr emitted before timeout fires (#83)", async () => {
+		// Generator emits two chunks, then waits for the abort signal. The
+		// returned CommandResult must contain the partial output, not empty
+		// strings.
+		const runCommand = vi.fn().mockResolvedValue({
+			exitCode: 0,
+			logs: (logsOpts?: { signal?: AbortSignal }) =>
+				(async function* () {
+					yield { stream: "stdout" as const, data: "chunk1\n" };
+					yield { stream: "stderr" as const, data: "warn1\n" };
+					await new Promise<void>((_, reject) => {
+						logsOpts?.signal?.addEventListener("abort", () =>
+							reject(new Error("aborted")),
+						);
+					});
+				})(),
+		});
+		const fakeSbx = makeVercelSandbox({ runCommand });
+		mockSandboxCreate.mockResolvedValue(fakeSbx);
+
+		const provider = createVercelProvider();
+		const result = await provider.create({});
+		if (!result.ok) throw new Error("unreachable");
+
+		const cmdRes = await result.instance.commands.run("slow-cmd", {
+			timeoutMs: 80,
+		});
+
+		expect(cmdRes.exitCode).toBe(-1);
+		expect(cmdRes.stdout).toBe("chunk1\n");
+		expect(cmdRes.stderr).toContain("warn1\n");
+	});
+
+	it("passes an abort signal into command.logs so the SDK can cancel the HTTP stream (#91)", async () => {
+		let receivedSignal: AbortSignal | undefined;
+		let signalAbortedDuringRun = false;
+
+		const runCommand = vi.fn().mockResolvedValue({
+			exitCode: 0,
+			logs: (logsOpts?: { signal?: AbortSignal }) => {
+				receivedSignal = logsOpts?.signal;
+				return (async function* () {
+					yield { stream: "stdout" as const, data: "partial\n" };
+					await new Promise<void>((_, reject) => {
+						logsOpts?.signal?.addEventListener("abort", () => {
+							signalAbortedDuringRun = true;
+							reject(new Error("aborted"));
+						});
+					});
+				})();
+			},
+		});
+		const fakeSbx = makeVercelSandbox({ runCommand });
+		mockSandboxCreate.mockResolvedValue(fakeSbx);
+
+		const provider = createVercelProvider();
+		const result = await provider.create({});
+		if (!result.ok) throw new Error("unreachable");
+
+		await result.instance.commands.run("slow-cmd", { timeoutMs: 50 });
+
+		expect(receivedSignal).toBeDefined();
+		expect(signalAbortedDuringRun).toBe(true);
 	});
 
 	it("commands.run handles StreamError mid-stream and returns partial output", async () => {

--- a/packages/core/src/providers/vercel.ts
+++ b/packages/core/src/providers/vercel.ts
@@ -52,32 +52,48 @@ function isTimeoutError(err: unknown): boolean {
 // Streaming bridge: AsyncGenerator logs → callbacks + collected strings
 // ---------------------------------------------------------------------------
 
+// Accumulator shared between collectLogs and run() so the timeout path can
+// observe partial output without waiting for collectLogs to settle.
+interface LogAccumulator {
+	stdout: string;
+	stderr: string;
+}
+
 async function collectLogs(
-	logsGenerator: () => AsyncGenerator<{
-		stream: "stdout" | "stderr";
-		data: string;
-	}>,
+	logsGenerator: (opts?: {
+		signal?: AbortSignal;
+	}) => AsyncGenerator<{ stream: "stdout" | "stderr"; data: string }>,
+	accumulator: LogAccumulator,
 	opts?: CommandOptions,
-): Promise<{ stdout: string; stderr: string }> {
-	let stdout = "";
-	let stderr = "";
+	signal?: AbortSignal,
+): Promise<void> {
+	// Pass the abort signal into the SDK so the underlying HTTP log-streaming
+	// request can be cancelled mid-flight when timeout/abort fires.
+	const iter = logsGenerator(signal ? { signal } : undefined);
 
 	try {
-		for await (const entry of logsGenerator()) {
+		for await (const entry of iter) {
 			if (entry.stream === "stdout") {
-				stdout += entry.data;
+				accumulator.stdout += entry.data;
 				opts?.onStdout?.(entry.data);
 			} else {
-				stderr += entry.data;
+				accumulator.stderr += entry.data;
 				opts?.onStderr?.(entry.data);
 			}
 		}
 	} catch (_err) {
-		// StreamError or other mid-stream errors: return partial output collected so far
-		// Do not rethrow — partial output is better than a hard failure
+		// StreamError, cancellation, or other mid-stream errors: partial output
+		// is already in `accumulator`. Do not rethrow.
+	} finally {
+		// Best-effort: close the iterator so the SDK releases its HTTP socket.
+		// `return()` is a standard async iterator method; SDKs may also expose
+		// `.close()` on the generator instance.
+		try {
+			await iter.return?.(undefined);
+		} catch {
+			// ignore
+		}
 	}
-
-	return { stdout, stderr };
 }
 
 // ---------------------------------------------------------------------------
@@ -207,15 +223,21 @@ export function createVercelProvider(): SandboxProvider {
 							// Wrap with sh -c so shell operators (pipes, redirects, quotes) work
 							const command = await sbx.runCommand("sh", ["-c", cmd]);
 
-							// Collect logs with optional timeout
-							let stdout = "";
-							let stderr = "";
+							// Shared accumulator: collectLogs writes here as data
+							// arrives so the timeout path observes partial output.
+							const accumulator: LogAccumulator = { stdout: "", stderr: "" };
 
-							const logsPromise = (async () => {
-								const result = await collectLogs(command.logs, opts);
-								stdout = result.stdout;
-								stderr = result.stderr;
-							})();
+							// Drives stream cancellation when the timeout fires —
+							// passed into the SDK logs() call and signals the
+							// underlying HTTP request to close.
+							const logsAbort = new AbortController();
+
+							const logsPromise = collectLogs(
+								command.logs,
+								accumulator,
+								opts,
+								logsAbort.signal,
+							);
 
 							if (opts?.timeoutMs !== undefined) {
 								const timeoutPromise = new Promise<"timeout">((resolve) =>
@@ -226,9 +248,16 @@ export function createVercelProvider(): SandboxProvider {
 									timeoutPromise,
 								]);
 								if (raceResult === "timeout") {
+									// Signal the SDK to abort the log stream and wait
+									// for collectLogs to settle so its iter.return()
+									// cleanup runs and the accumulator is final.
+									logsAbort.abort();
+									await logsPromise;
 									return {
-										stdout,
-										stderr: stderr || "Command timeout: exceeded time limit",
+										stdout: accumulator.stdout,
+										stderr:
+											accumulator.stderr ||
+											"Command timeout: exceeded time limit",
 										exitCode: -1,
 									};
 								}
@@ -236,7 +265,11 @@ export function createVercelProvider(): SandboxProvider {
 								await logsPromise;
 							}
 
-							return { stdout, stderr, exitCode: command.exitCode };
+							return {
+								stdout: accumulator.stdout,
+								stderr: accumulator.stderr,
+								exitCode: command.exitCode,
+							};
 						},
 					},
 					async kill(): Promise<void> {


### PR DESCRIPTION
## Summary
Two related bugs in `commands.run()`'s timeout handling, both rooted in how `collectLogs()` was wired:

1. **Partial output dropped on timeout (#83)** — `stdout`/`stderr` were only assigned to outer-scope variables AFTER `collectLogs` settled. On timeout, the function returned empty strings even though chunks had already been accumulated.
2. **Log stream HTTP connection leaked on timeout (#91)** — `collectLogs` invoked the SDK generator with no arguments and never retained the iterator. On timeout the generator was abandoned, leaving its underlying HTTP stream open until sandbox idle timeout (5 min on Vercel).

Refactor:
- `collectLogs` takes a shared accumulator written per-entry, so the outer scope sees partial output as it arrives.
- Passes `{ signal }` into `logsGenerator()` so the Vercel SDK cancels its HTTP stream when the timeout AbortController fires.
- Calls `iter.return?.()` in `finally` as belt-and-suspenders cleanup.

In `run()`, on timeout: trigger `logsAbort.abort()`, await `logsPromise` to settle (cleanup runs, accumulator is final), then return.

Fixes #83
Fixes #91

## Test plan
- [x] New test asserts partial `chunk1\n` is returned on timeout (fails on main)
- [x] New test asserts the SDK receives an abort signal that fires during run (fails on main)
- [x] Existing timeout test still asserts `exitCode: -1` and timeout message
- [x] All 30 vercel provider tests pass