### PR TITLE
fix(sandbox): register SIGTERM handler before composite pre-await

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -173,7 +173,7 @@
     "@protobufjs/utf8": ">=1.1.1",
     "axios": ">=1.15.2",
     "basic-ftp": ">=5.2.1",
-    "brace-expansion": ">=2.0.3",
+    "brace-expansion": ">=5.0.6",
     "defu": ">=6.1.5",
     "devalue": ">=5.8.1",
     "fast-uri": ">=3.1.2",
@@ -188,6 +188,7 @@
     "protobufjs": ">=7.5.6",
     "smol-toml": ">=1.6.1",
     "undici": "^7.24.0",
+    "ws": ">=8.20.1",
     "yaml": ">=2.8.3",
   },
   "packages": {
@@ -1067,7 +1068,7 @@
 
     "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
-    "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
+    "brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
@@ -2283,7 +2284,7 @@
 
     "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
-    "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
+    "ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
 
     "xdg-app-paths": ["xdg-app-paths@5.1.0", "", { "dependencies": { "xdg-portable": "^7.0.0" } }, "sha512-RAQ3WkPf4KTU1A8RtFx3gWywzVKe00tfOPFfl2NDGqbIFENQO4kqAJp7mhQjNj/33W5x5hiWWUdyfPq/5SU3QA=="],
 
@@ -2462,8 +2463,6 @@
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
     "miniflare/sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
-
-    "miniflare/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
 
     "node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 		"@protobufjs/utf8": ">=1.1.1",
 		"axios": ">=1.15.2",
 		"basic-ftp": ">=5.2.1",
-		"brace-expansion": ">=2.0.3",
+		"brace-expansion": ">=5.0.6",
 		"defu": ">=6.1.5",
 		"devalue": ">=5.8.1",
 		"fast-uri": ">=3.1.2",
@@ -46,6 +46,7 @@
 		"protobufjs": ">=7.5.6",
 		"smol-toml": ">=1.6.1",
 		"undici": "^7.24.0",
+		"ws": ">=8.20.1",
 		"yaml": ">=2.8.3"
 	},
 	"dependencies": {

--- a/packages/core/src/__tests__/sandbox.test.ts
+++ b/packages/core/src/__tests__/sandbox.test.ts
@@ -1257,8 +1257,7 @@ describe("runAgentInSandbox — composite orchestration", () => {
 		] as number;
 		const ipcCleanupOrder = instance.commands.run.mock.invocationCallOrder[
 			instance.commands.run.mock.calls.findIndex(
-				(c) =>
-					typeof c[0] === "string" && c[0].includes("sandcaster-ipc-"),
+				(c) => typeof c[0] === "string" && c[0].includes("sandcaster-ipc-"),
 			)
 		] as number;
 

--- a/packages/core/src/__tests__/sandbox.test.ts
+++ b/packages/core/src/__tests__/sandbox.test.ts
@@ -1225,6 +1225,48 @@ describe("runAgentInSandbox — composite orchestration", () => {
 		onSpy.mockRestore();
 	});
 
+	it("registers SIGTERM handler before any await in composite pre-work", async () => {
+		// In composite mode, sandbox.ts runs `await instance.commands.run("rm -f
+		// /tmp/sandcaster-ipc-*.json*")` to clear stale IPC files. If SIGTERM
+		// arrives during that await and no handler is registered, Node exits
+		// immediately and the sandbox leaks. The handler must be installed
+		// before the first awaited operation following sandbox creation.
+		const instance = makeCompositeInstance([]);
+		registerFakeProvider(instance);
+
+		const onSpy = vi.spyOn(process, "once");
+
+		for await (const _ of runAgentInSandbox({
+			request: makeRequest({ composite: { maxSandboxes: 2 } }),
+		})) {
+			// consume
+		}
+
+		const sigtermCall = onSpy.mock.calls.find((call) => call[0] === "SIGTERM");
+		expect(sigtermCall).toBeDefined();
+
+		// Find the IPC cleanup call to instance.commands.run.
+		const ipcCleanupCall = instance.commands.run.mock.calls.find(
+			(call) =>
+				typeof call[0] === "string" && call[0].includes("sandcaster-ipc-"),
+		);
+		expect(ipcCleanupCall).toBeDefined();
+
+		const sigtermOrder = onSpy.mock.invocationCallOrder[
+			onSpy.mock.calls.findIndex((c) => c[0] === "SIGTERM")
+		] as number;
+		const ipcCleanupOrder = instance.commands.run.mock.invocationCallOrder[
+			instance.commands.run.mock.calls.findIndex(
+				(c) =>
+					typeof c[0] === "string" && c[0].includes("sandcaster-ipc-"),
+			)
+		] as number;
+
+		expect(sigtermOrder).toBeLessThan(ipcCleanupOrder);
+
+		onSpy.mockRestore();
+	});
+
 	it("registers a SIGTERM handler that kills the instance in non-composite mode", async () => {
 		// Without a SIGTERM handler, Node exits immediately on signal and the
 		// `finally` block that calls `instance.kill()` never runs, leaving the

--- a/packages/core/src/sandbox.ts
+++ b/packages/core/src/sandbox.ts
@@ -277,6 +277,21 @@ export async function* runAgentInSandbox(
 	let compositeNonce: string | undefined;
 	let resolvedComposite: ReturnType<typeof resolveCompositeConfig> | undefined;
 
+	// Register SIGTERM handler for graceful cleanup BEFORE any await that
+	// follows sandbox creation. Required for both modes: without a handler,
+	// Node exits immediately on SIGTERM and the `finally` block at the bottom
+	// of this function never runs — leaving the sandbox alive until the
+	// provider's idle timeout (5 min on E2B). Composite mode kills the whole
+	// pool (set below); non-composite kills the single instance.
+	const sigTermHandler: () => Promise<void> = async () => {
+		if (pool !== undefined) {
+			await pool.killAll();
+		} else {
+			await instance.kill();
+		}
+	};
+	process.once("SIGTERM", sigTermHandler);
+
 	if (compositeActive) {
 		resolvedComposite = resolveCompositeConfig(
 			config?.composite,
@@ -326,20 +341,6 @@ export async function* runAgentInSandbox(
 		// Stale IPC cleanup
 		await instance.commands.run(`rm -f /tmp/sandcaster-ipc-*.json*`);
 	}
-
-	// Register SIGTERM handler for graceful cleanup. Required for both modes:
-	// without a handler, Node exits immediately on SIGTERM and the `finally`
-	// block at the bottom of this function never runs — leaving the sandbox
-	// alive until the provider's idle timeout (5 min on E2B). Composite mode
-	// kills the whole pool; non-composite kills the single instance.
-	const sigTermHandler: () => Promise<void> = async () => {
-		if (pool !== undefined) {
-			await pool.killAll();
-		} else {
-			await instance.kill();
-		}
-	};
-	process.once("SIGTERM", sigTermHandler);
 
 	// Runner directory — use instance.workDir so providers with restricted
 	// filesystems (e.g. Vercel) can write to a writable location.


### PR DESCRIPTION
## Summary
- In composite mode, the SIGTERM handler was registered after `await instance.commands.run(\`rm -f /tmp/sandcaster-ipc-*.json*\`)`. SIGTERM during that window terminated Node before any cleanup, leaking the E2B sandbox until the provider's idle timeout.
- Move `process.once(\"SIGTERM\", ...)` immediately after sandbox creation, before any await. The handler closes over `pool` by reference, so it observes the eventual composite pool assignment correctly.

Fixes #106.

## Test plan
- [x] New test asserts SIGTERM `process.once` is invoked before the composite IPC cleanup `commands.run` (uses `invocationCallOrder`).
- [x] Existing SIGTERM tests (composite + non-composite registration, handler removal) still pass (49/49).