### PR TITLE
chore(deps): bump vulnerable transitives (brace-expansion, ws)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -173,7 +173,7 @@
     "@protobufjs/utf8": ">=1.1.1",
     "axios": ">=1.15.2",
     "basic-ftp": ">=5.2.1",
-    "brace-expansion": ">=2.0.3",
+    "brace-expansion": ">=5.0.6",
     "defu": ">=6.1.5",
     "devalue": ">=5.8.1",
     "fast-uri": ">=3.1.2",
@@ -188,6 +188,7 @@
     "protobufjs": ">=7.5.6",
     "smol-toml": ">=1.6.1",
     "undici": "^7.24.0",
+    "ws": ">=8.20.1",
     "yaml": ">=2.8.3",
   },
   "packages": {
@@ -1067,7 +1068,7 @@
 
     "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
-    "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
+    "brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
@@ -2283,7 +2284,7 @@
 
     "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
-    "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
+    "ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
 
     "xdg-app-paths": ["xdg-app-paths@5.1.0", "", { "dependencies": { "xdg-portable": "^7.0.0" } }, "sha512-RAQ3WkPf4KTU1A8RtFx3gWywzVKe00tfOPFfl2NDGqbIFENQO4kqAJp7mhQjNj/33W5x5hiWWUdyfPq/5SU3QA=="],
 
@@ -2462,8 +2463,6 @@
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
     "miniflare/sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
-
-    "miniflare/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
 
     "node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 		"@protobufjs/utf8": ">=1.1.1",
 		"axios": ">=1.15.2",
 		"basic-ftp": ">=5.2.1",
-		"brace-expansion": ">=2.0.3",
+		"brace-expansion": ">=5.0.6",
 		"defu": ">=6.1.5",
 		"devalue": ">=5.8.1",
 		"fast-uri": ">=3.1.2",
@@ -46,6 +46,7 @@
 		"protobufjs": ">=7.5.6",
 		"smol-toml": ">=1.6.1",
 		"undici": "^7.24.0",
+		"ws": ">=8.20.1",
 		"yaml": ">=2.8.3"
 	},
 	"dependencies": {


### PR DESCRIPTION
## Summary
osv-scanner started flagging three medium-severity advisories on every PR's Security Audit job. All are in transitive deps tracked by the lockfile, not anything this repo imports directly:

| Package | From | To | Advisory | CVSS |
|---------|------|-----|----------|------|
| brace-expansion | 5.0.5 | 5.0.6 | GHSA-jxxr-4gwj-5jf2 | 6.5 |
| ws | 8.18.0 | 8.20.1 | GHSA-58qx-3vcg-4xpx | 4.4 |
| ws | 8.19.0 | 8.20.1 | GHSA-58qx-3vcg-4xpx | 4.4 |

- Tighten existing `brace-expansion` override `>=2.0.3` → `>=5.0.6`. Lockfile only resolves a single v5.x line, so no v1/v2 consumer is impacted.
- Add new `ws` override at `>=8.20.1` to upgrade both transitive copies.

## Test plan
- [x] `bunx turbo build` — 6 packages green
- [x] `bunx turbo test` — 908 tests pass
- [x] `bun pm ls --all | grep -E "brace-expansion |^├── ws@"` shows `brace-expansion@5.0.6` + `ws@8.20.1`
- [ ] CI Security Audit on this branch goes green (verifies advisories no longer match)